### PR TITLE
Benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ install(
 macro(beman_add_executable)
     set(options)
     set(oneValueArgs CATEGORY TARGET)
-    set(multiValueArgs SOURCES LIBRARIES)
+    set(multiValueArgs FEATURES SOURCES LIBRARIES)
 
     cmake_parse_arguments(
         beman_executable
@@ -98,10 +98,14 @@ macro(beman_add_executable)
         set(beman_executable_SOURCES "${beman_executable_TARGET}.cpp")
     endif()
 
+    if(NOT beman_executable_FEATURES)
+        set(${beman_executable_FEATURES} cxx_std_20)
+    endif()
+
     add_executable(${target})
     # [CMAKE.PASSIVE_PROJECTS]
     # set features on executables, not on interface library
-    target_compile_features(${target} PRIVATE cxx_std_20)
+    target_compile_features(${target} PRIVATE ${beman_executable_FEATURES})
     target_sources(${target} PRIVATE ${beman_executable_SOURCES})
     target_link_libraries(
         ${target}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ install(
     PATTERN "${CMAKE_CURRENT_BINARY_DIR}/include/beman/any_view/*.hpp"
 )
 
-macro(beman_add_executable)
+function(beman_add_executable)
     set(options)
     set(oneValueArgs CATEGORY TARGET)
     set(multiValueArgs SOURCES LIBRARIES)
@@ -90,13 +90,8 @@ macro(beman_add_executable)
     )
 
     # [CMAKE.TARGET_NAMES]
-    set(target
-        "beman.any_view.${beman_executable_CATEGORY}.${beman_executable_TARGET}"
-    )
-
-    if(NOT beman_executable_SOURCES)
-        set(beman_executable_SOURCES "${beman_executable_TARGET}.cpp")
-    endif()
+    set(category beman.any_view.${beman_executable_CATEGORY})
+    set(target ${category}.${beman_executable_TARGET})
 
     add_executable(${target})
     # [CMAKE.PASSIVE_PROJECTS]
@@ -107,7 +102,13 @@ macro(beman_add_executable)
         ${target}
         PRIVATE beman::any_view ${beman_executable_LIBRARIES}
     )
-endmacro()
+
+    if(NOT TARGET ${category})
+        add_custom_target(${category})
+    endif()
+
+    add_dependencies(${category} ${target})
+endfunction()
 
 if(BEMAN_ANY_VIEW_BUILD_TESTS)
     enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ install(
 macro(beman_add_executable)
     set(options)
     set(oneValueArgs CATEGORY TARGET)
-    set(multiValueArgs FEATURES SOURCES LIBRARIES)
+    set(multiValueArgs SOURCES LIBRARIES)
 
     cmake_parse_arguments(
         beman_executable
@@ -98,14 +98,10 @@ macro(beman_add_executable)
         set(beman_executable_SOURCES "${beman_executable_TARGET}.cpp")
     endif()
 
-    if(NOT beman_executable_FEATURES)
-        set(${beman_executable_FEATURES} cxx_std_20)
-    endif()
-
     add_executable(${target})
     # [CMAKE.PASSIVE_PROJECTS]
     # set features on executables, not on interface library
-    target_compile_features(${target} PRIVATE ${beman_executable_FEATURES})
+    target_compile_features(${target} PRIVATE cxx_std_20)
     target_sources(${target} PRIVATE ${beman_executable_SOURCES})
     target_link_libraries(
         ${target}

--- a/tests/beman/any_view/CMakeLists.txt
+++ b/tests/beman/any_view/CMakeLists.txt
@@ -29,8 +29,8 @@ function(beman_add_test)
     gtest_discover_tests(${target})
 endfunction()
 
-beman_add_benchmark(TARGET all SOURCES all.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp)
-beman_add_benchmark(TARGET take SOURCES take.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp)
+beman_add_benchmark(TARGET all SOURCES all.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp detail/reserved.cpp)
+beman_add_benchmark(TARGET take SOURCES take.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp detail/reserved.cpp)
 
 beman_add_test(TARGET concepts SOURCES concepts.test.cpp)
 beman_add_test(TARGET constexpr SOURCES constexpr.test.cpp)

--- a/tests/beman/any_view/CMakeLists.txt
+++ b/tests/beman/any_view/CMakeLists.txt
@@ -20,19 +20,47 @@ FetchContent_MakeAvailable(benchmark googletest)
 
 include(GoogleTest)
 
-function(beman_add_benchmark)
-    beman_add_executable(${ARGN} CATEGORY benchmarks LIBRARIES benchmark::benchmark)
+function(beman_add_benchmark name)
+    beman_add_executable(
+        TARGET ${name}
+        SOURCES ${name}.benchmark.cpp ${ARGN}
+        CATEGORY benchmarks
+        LIBRARIES benchmark::benchmark
+    )
 endfunction()
 
-function(beman_add_test)
-    beman_add_executable(${ARGN} CATEGORY tests LIBRARIES GTest::gtest GTest::gtest_main)
-    gtest_discover_tests(${target})
+function(beman_add_tests)
+    foreach(name ${ARGN})
+        beman_add_executable(
+            TARGET ${name}
+            SOURCES ${name}.test.cpp
+            CATEGORY tests
+            LIBRARIES GTest::gtest GTest::gtest_main
+        )
+        gtest_discover_tests(beman.any_view.tests.${name})
+    endforeach()
 endfunction()
 
-beman_add_benchmark(TARGET all SOURCES all.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp detail/reserved.cpp)
-beman_add_benchmark(TARGET take SOURCES take.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp detail/reserved.cpp)
+beman_add_benchmark(
+    all
+    detail/eager.cpp
+    detail/fused.cpp
+    detail/lazy.cpp
+    detail/products.cpp
+    detail/reserved.cpp
+)
+beman_add_benchmark(
+    take
+    detail/eager.cpp
+    detail/fused.cpp
+    detail/lazy.cpp
+    detail/products.cpp
+    detail/reserved.cpp
+)
 
-beman_add_test(TARGET concepts SOURCES concepts.test.cpp)
-beman_add_test(TARGET constexpr SOURCES constexpr.test.cpp)
-beman_add_test(TARGET sfinae SOURCES sfinae.test.cpp)
-beman_add_test(TARGET type_traits SOURCES type_traits.test.cpp)
+beman_add_tests(
+    concepts
+    constexpr
+    sfinae
+    type_traits
+)

--- a/tests/beman/any_view/CMakeLists.txt
+++ b/tests/beman/any_view/CMakeLists.txt
@@ -29,8 +29,8 @@ function(beman_add_test)
     gtest_discover_tests(${target})
 endfunction()
 
-beman_add_benchmark(TARGET all SOURCES all.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp FEATURES cxx_std_23)
-beman_add_benchmark(TARGET take SOURCES take.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp FEATURES cxx_std_23)
+beman_add_benchmark(TARGET all SOURCES all.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp)
+beman_add_benchmark(TARGET take SOURCES take.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp)
 
 beman_add_test(TARGET concepts SOURCES concepts.test.cpp)
 beman_add_test(TARGET constexpr SOURCES constexpr.test.cpp)

--- a/tests/beman/any_view/CMakeLists.txt
+++ b/tests/beman/any_view/CMakeLists.txt
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# Fetch Benchmark
+FetchContent_Declare(
+    benchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG v1.9.2
+    EXCLUDE_FROM_ALL
+)
+set(BENCHMARK_ENABLE_TESTING OFF)
 # Fetch GoogleTest
 FetchContent_Declare(
     googletest
@@ -8,16 +16,21 @@ FetchContent_Declare(
     EXCLUDE_FROM_ALL
 )
 set(INSTALL_GTEST OFF) # Disable GoogleTest installation
-FetchContent_MakeAvailable(googletest)
+FetchContent_MakeAvailable(benchmark googletest)
 
 include(GoogleTest)
 
+function(beman_add_benchmark)
+    beman_add_executable(${ARGN} CATEGORY benchmarks LIBRARIES benchmark::benchmark)
+endfunction()
+
 function(beman_add_test)
-    beman_add_executable(${ARGN} CATEGORY tests LIBRARIES GTest::gtest
-                         GTest::gtest_main
-    )
+    beman_add_executable(${ARGN} CATEGORY tests LIBRARIES GTest::gtest GTest::gtest_main)
     gtest_discover_tests(${target})
 endfunction()
+
+beman_add_benchmark(TARGET all SOURCES all.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp FEATURES cxx_std_23)
+beman_add_benchmark(TARGET take SOURCES take.benchmark.cpp detail/eager.cpp detail/fused.cpp detail/lazy.cpp detail/products.cpp FEATURES cxx_std_23)
 
 beman_add_test(TARGET concepts SOURCES concepts.test.cpp)
 beman_add_test(TARGET constexpr SOURCES constexpr.test.cpp)

--- a/tests/beman/any_view/all.benchmark.cpp
+++ b/tests/beman/any_view/all.benchmark.cpp
@@ -4,6 +4,7 @@
 #include "detail/fused.hpp"
 #include "detail/lazy.hpp"
 #include "detail/products.hpp"
+#include "detail/reserved.hpp"
 
 #include <benchmark/benchmark.h>
 
@@ -57,8 +58,22 @@ static void BM_all_lazy(benchmark::State& state) {
     }
 }
 
+static void BM_all_reserved(benchmark::State& state) {
+    const auto size  = state.range(0);
+    const auto begin = global_products.begin();
+
+    reserved::database db{.products = {begin, begin + size}};
+
+    for (auto _ : state) {
+        for (std::string_view name : db.get_products({.min_quantity = 10})) {
+            use(name);
+        }
+    }
+}
+
 BENCHMARK(BM_all_eager)->RangeMultiplier(2)->Range(1 << 10, max_size);
 BENCHMARK(BM_all_fused)->RangeMultiplier(2)->Range(1 << 10, max_size);
 BENCHMARK(BM_all_lazy)->RangeMultiplier(2)->Range(1 << 10, max_size);
+BENCHMARK(BM_all_reserved)->RangeMultiplier(2)->Range(1 << 10, max_size);
 
 BENCHMARK_MAIN();

--- a/tests/beman/any_view/all.benchmark.cpp
+++ b/tests/beman/any_view/all.benchmark.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "detail/eager.hpp"
+#include "detail/fused.hpp"
+#include "detail/lazy.hpp"
+#include "detail/products.hpp"
+
+#include <benchmark/benchmark.h>
+
+constexpr auto max_size = 1 << 18;
+
+const auto global_products = generate_random_products(max_size);
+
+inline void use(std::string_view name) {
+    auto front = name.front();
+    auto back  = name.back();
+    benchmark::DoNotOptimize(front);
+    benchmark::DoNotOptimize(back);
+}
+
+static void BM_all_eager(benchmark::State& state) {
+    eager::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+
+    for (auto _ : state) {
+        for (std::string_view name : db.get_products({.min_quantity = 10})) {
+            use(name);
+        }
+    }
+}
+
+static void BM_all_fused(benchmark::State& state) {
+    fused::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+
+    for (auto _ : state) {
+        for (std::string_view name : db.get_products({.min_quantity = 10})) {
+            use(name);
+        }
+    }
+}
+
+static void BM_all_lazy(benchmark::State& state) {
+    lazy::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+
+    for (auto _ : state) {
+        for (std::string_view name : db.get_products({.min_quantity = 10})) {
+            use(name);
+        }
+    }
+}
+
+BENCHMARK(BM_all_eager)->RangeMultiplier(2)->Range(1 << 10, max_size);
+BENCHMARK(BM_all_fused)->RangeMultiplier(2)->Range(1 << 10, max_size);
+BENCHMARK(BM_all_lazy)->RangeMultiplier(2)->Range(1 << 10, max_size);
+
+BENCHMARK_MAIN();

--- a/tests/beman/any_view/all.benchmark.cpp
+++ b/tests/beman/any_view/all.benchmark.cpp
@@ -19,7 +19,10 @@ inline void use(std::string_view name) {
 }
 
 static void BM_all_eager(benchmark::State& state) {
-    eager::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+    const auto size  = state.range(0);
+    const auto begin = global_products.begin();
+
+    eager::database db{.products = {begin, begin + size}};
 
     for (auto _ : state) {
         for (std::string_view name : db.get_products({.min_quantity = 10})) {
@@ -29,7 +32,10 @@ static void BM_all_eager(benchmark::State& state) {
 }
 
 static void BM_all_fused(benchmark::State& state) {
-    fused::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+    const auto size  = state.range(0);
+    const auto begin = global_products.begin();
+
+    fused::database db{.products = {begin, begin + size}};
 
     for (auto _ : state) {
         for (std::string_view name : db.get_products({.min_quantity = 10})) {
@@ -39,7 +45,10 @@ static void BM_all_fused(benchmark::State& state) {
 }
 
 static void BM_all_lazy(benchmark::State& state) {
-    lazy::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+    const auto size  = state.range(0);
+    const auto begin = global_products.begin();
+
+    lazy::database db{.products = {begin, begin + size}};
 
     for (auto _ : state) {
         for (std::string_view name : db.get_products({.min_quantity = 10})) {

--- a/tests/beman/any_view/detail/eager.cpp
+++ b/tests/beman/any_view/detail/eager.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "eager.hpp"
+
+auto eager::database::get_products(query_t query) const -> names_t {
+    names_t results;
+
+    for (const auto& product : products) {
+        if (product.quantity >= query.min_quantity) {
+            results.push_back(product.name);
+        }
+    }
+
+    return results;
+}

--- a/tests/beman/any_view/detail/eager.cpp
+++ b/tests/beman/any_view/detail/eager.cpp
@@ -7,7 +7,7 @@ auto eager::database::get_products(query_t query) const -> names_t {
 
     for (const auto& product : products) {
         if (product.quantity >= query.min_quantity) {
-            results.push_back(product.name);
+            results.emplace_back(product.name);
         }
     }
 

--- a/tests/beman/any_view/detail/eager.hpp
+++ b/tests/beman/any_view/detail/eager.hpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "product.hpp"
+
+#include <vector>
+
+namespace eager {
+
+using names_t = std::vector<std::string_view>;
+
+struct database {
+    std::vector<product_t> products;
+
+    auto get_products(query_t) const -> names_t;
+};
+
+} // namespace eager

--- a/tests/beman/any_view/detail/fused.cpp
+++ b/tests/beman/any_view/detail/fused.cpp
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "fused.hpp"
+
+auto fused::database::get_products(query_t query) const -> names_t {
+    return products | std::views::filter([=](const product_t& product) -> bool {
+               return product.quantity >= query.min_quantity;
+           }) |
+           std::views::transform(&product_t::name);
+}

--- a/tests/beman/any_view/detail/fused.hpp
+++ b/tests/beman/any_view/detail/fused.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "product.hpp"
+
+#include <beman/any_view/any_view.hpp>
+
+#include <vector>
+
+namespace fused {
+
+using names_t = beman::any_view::any_view<const std::string, beman::any_view::any_view_options::forward>;
+
+struct database {
+    std::vector<product_t> products;
+
+    auto get_products(query_t) const -> names_t;
+};
+
+} // namespace fused

--- a/tests/beman/any_view/detail/lazy.cpp
+++ b/tests/beman/any_view/detail/lazy.cpp
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "lazy.hpp"
+
+auto lazy::database::get_products(query_t query) const -> names_t {
+    return products | std::views::filter([=](const product_t& product) -> bool {
+               return product.quantity >= query.min_quantity;
+           }) |
+           std::views::transform(&product_t::name);
+}

--- a/tests/beman/any_view/detail/lazy.hpp
+++ b/tests/beman/any_view/detail/lazy.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "product.hpp"
+
+#include <beman/any_view/any_view.hpp>
+
+#include <vector>
+
+namespace lazy {
+
+using names_t = beman::any_view::any_view<const std::string>;
+
+struct database {
+    std::vector<product_t> products;
+
+    auto get_products(query_t) const -> names_t;
+};
+
+} // namespace lazy

--- a/tests/beman/any_view/detail/product.hpp
+++ b/tests/beman/any_view/detail/product.hpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <string>
+
+struct product_t {
+    std::string name;
+    std::size_t quantity;
+};
+
+struct query_t {
+    std::size_t min_quantity;
+};

--- a/tests/beman/any_view/detail/products.cpp
+++ b/tests/beman/any_view/detail/products.cpp
@@ -32,10 +32,10 @@ auto generate_random_products(std::size_t count) -> std::vector<product_t> {
     std::mt19937                       w_rng;
     std::uniform_int_distribution<int> w_dist(0, 100);
 
-    const auto gen_size = [&] { return w_dist(w_rng); };
+    const auto gen_size = [&]() -> std::size_t { return w_dist(w_rng); };
 
     for (std::size_t i = 0; i < results.capacity(); ++i) {
-        results.emplace_back(gen_next_str(), gen_size());
+        results.push_back(product_t{.name = gen_next_str(), .quantity = gen_size()});
     }
 
     return results;

--- a/tests/beman/any_view/detail/products.cpp
+++ b/tests/beman/any_view/detail/products.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "products.hpp"
+
+#include <random>
+
+auto generate_random_products(std::size_t count) -> std::vector<product_t> {
+    std::vector<product_t> results;
+    results.reserve(count);
+
+    constexpr char alphanum[] = "0123456789"
+                                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                "abcdefghijklmnopqrstuvwxyz";
+
+    std::mt19937                                             char_rng;
+    std::uniform_int_distribution<std::mt19937::result_type> char_dist(0, sizeof(alphanum) - 1);
+
+    std::mt19937                                             len_rng;
+    std::uniform_int_distribution<std::mt19937::result_type> len_dist(1, 30);
+
+    const auto gen_next_str = [&]() {
+        std::string str;
+        str.reserve(len_dist(len_rng));
+
+        for (std::size_t i = 0; i < str.capacity(); ++i) {
+            str.push_back(alphanum[char_dist(char_rng)]);
+        }
+
+        return str;
+    };
+
+    std::mt19937                       w_rng;
+    std::uniform_int_distribution<int> w_dist(0, 100);
+
+    const auto gen_size = [&] { return w_dist(w_rng); };
+
+    for (std::size_t i = 0; i < results.capacity(); ++i) {
+        results.emplace_back(gen_next_str(), gen_size());
+    }
+
+    return results;
+}

--- a/tests/beman/any_view/detail/products.hpp
+++ b/tests/beman/any_view/detail/products.hpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "product.hpp"
+
+#include <vector>
+
+auto generate_random_products(std::size_t count) -> std::vector<product_t>;

--- a/tests/beman/any_view/detail/reserved.cpp
+++ b/tests/beman/any_view/detail/reserved.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "reserved.hpp"
+
+#include <algorithm>
+
+auto reserved::database::get_products(query_t query) const -> names_t {
+    const auto capacity = std::ranges::count_if(
+        products, [=](const product_t& product) -> bool { return product.quantity >= query.min_quantity; });
+
+    names_t results;
+    results.reserve(capacity);
+
+    for (const auto& product : products) {
+        if (product.quantity >= query.min_quantity) {
+            results.emplace_back(product.name);
+        }
+    }
+
+    return results;
+}

--- a/tests/beman/any_view/detail/reserved.hpp
+++ b/tests/beman/any_view/detail/reserved.hpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "product.hpp"
+
+#include <vector>
+
+namespace reserved {
+
+using names_t = std::vector<std::string_view>;
+
+struct database {
+    std::vector<product_t> products;
+
+    auto get_products(query_t) const -> names_t;
+};
+
+} // namespace reserved

--- a/tests/beman/any_view/take.benchmark.cpp
+++ b/tests/beman/any_view/take.benchmark.cpp
@@ -4,6 +4,7 @@
 #include "detail/fused.hpp"
 #include "detail/lazy.hpp"
 #include "detail/products.hpp"
+#include "detail/reserved.hpp"
 
 #include <benchmark/benchmark.h>
 
@@ -57,8 +58,22 @@ static void BM_take_lazy(benchmark::State& state) {
     }
 }
 
+static void BM_take_reserved(benchmark::State& state) {
+    const auto size  = state.range(0);
+    const auto begin = global_products.begin();
+
+    reserved::database db{.products = {begin, begin + size}};
+
+    for (auto _ : state) {
+        for (std::string_view name : db.get_products({.min_quantity = 10}) | std::views::take(100)) {
+            use(name);
+        }
+    }
+}
+
 BENCHMARK(BM_take_eager)->RangeMultiplier(2)->Range(1 << 10, max_size);
 BENCHMARK(BM_take_fused)->RangeMultiplier(2)->Range(1 << 10, max_size);
 BENCHMARK(BM_take_lazy)->RangeMultiplier(2)->Range(1 << 10, max_size);
+BENCHMARK(BM_take_reserved)->RangeMultiplier(2)->Range(1 << 10, max_size);
 
 BENCHMARK_MAIN();

--- a/tests/beman/any_view/take.benchmark.cpp
+++ b/tests/beman/any_view/take.benchmark.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "detail/eager.hpp"
+#include "detail/fused.hpp"
+#include "detail/lazy.hpp"
+#include "detail/products.hpp"
+
+#include <benchmark/benchmark.h>
+
+constexpr auto max_size = 1 << 18;
+
+const auto global_products = generate_random_products(max_size);
+
+inline void use(std::string_view name) {
+    auto front = name.front();
+    auto back  = name.back();
+    benchmark::DoNotOptimize(front);
+    benchmark::DoNotOptimize(back);
+}
+
+static void BM_take_eager(benchmark::State& state) {
+    eager::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+
+    for (auto _ : state) {
+        for (std::string_view name : db.get_products({.min_quantity = 10}) | std::views::take(100)) {
+            use(name);
+        }
+    }
+}
+
+static void BM_take_fused(benchmark::State& state) {
+    fused::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+
+    for (auto _ : state) {
+        for (std::string_view name : db.get_products({.min_quantity = 10}) | std::views::take(100)) {
+            use(name);
+        }
+    }
+}
+
+static void BM_take_lazy(benchmark::State& state) {
+    lazy::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+
+    for (auto _ : state) {
+        for (std::string_view name : db.get_products({.min_quantity = 10}) | std::views::take(100)) {
+            use(name);
+        }
+    }
+}
+
+BENCHMARK(BM_take_eager)->RangeMultiplier(2)->Range(1 << 10, max_size);
+BENCHMARK(BM_take_fused)->RangeMultiplier(2)->Range(1 << 10, max_size);
+BENCHMARK(BM_take_lazy)->RangeMultiplier(2)->Range(1 << 10, max_size);
+
+BENCHMARK_MAIN();

--- a/tests/beman/any_view/take.benchmark.cpp
+++ b/tests/beman/any_view/take.benchmark.cpp
@@ -19,7 +19,10 @@ inline void use(std::string_view name) {
 }
 
 static void BM_take_eager(benchmark::State& state) {
-    eager::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+    const auto size  = state.range(0);
+    const auto begin = global_products.begin();
+
+    eager::database db{.products = {begin, begin + size}};
 
     for (auto _ : state) {
         for (std::string_view name : db.get_products({.min_quantity = 10}) | std::views::take(100)) {
@@ -29,7 +32,10 @@ static void BM_take_eager(benchmark::State& state) {
 }
 
 static void BM_take_fused(benchmark::State& state) {
-    fused::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+    const auto size  = state.range(0);
+    const auto begin = global_products.begin();
+
+    fused::database db{.products = {begin, begin + size}};
 
     for (auto _ : state) {
         for (std::string_view name : db.get_products({.min_quantity = 10}) | std::views::take(100)) {
@@ -39,7 +45,10 @@ static void BM_take_fused(benchmark::State& state) {
 }
 
 static void BM_take_lazy(benchmark::State& state) {
-    lazy::database db{global_products | std::views::take(state.range(0)) | std::ranges::to<std::vector>()};
+    const auto size  = state.range(0);
+    const auto begin = global_products.begin();
+
+    lazy::database db{.products = {begin, begin + size}};
 
     for (auto _ : state) {
         for (std::string_view name : db.get_products({.min_quantity = 10}) | std::views::take(100)) {


### PR DESCRIPTION
`beman.any_view.benchmarks.all` results for `lazy` vs. `fused`:
```
Comparing lazy (from build/tests/beman/any_view/beman.any_view.benchmarks.all) to fused (from build/tests/beman/any_view/beman.any_view.benchmarks.all)
Benchmark                                        Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------------------
BM_all_[lazy vs. fused]/1024                  -0.5196         -0.5196          2897          1392          2897          1392
BM_all_[lazy vs. fused]/2048                  -0.5183         -0.5183          5847          2817          5846          2817
BM_all_[lazy vs. fused]/4096                  -0.4509         -0.4509         11662          6404         11662          6404
BM_all_[lazy vs. fused]/8192                  -0.4214         -0.4214         23853         13801         23853         13801
BM_all_[lazy vs. fused]/16384                 -0.4039         -0.4039         50693         30219         50694         30218
BM_all_[lazy vs. fused]/32768                 -0.3683         -0.3683         98741         62376         98741         62376
BM_all_[lazy vs. fused]/65536                 -0.3610         -0.3610        200704        128248        200704        128247
BM_all_[lazy vs. fused]/131072                -0.3399         -0.3389        410100        270726        409501        270725
BM_all_[lazy vs. fused]/262144                -0.3110         -0.3110        827544        570211        827538        570211
OVERALL_GEOMEAN                               -0.4148         -0.4147
```
Overall a mean improvement of ~41% using the cache object on the iterator to reduce virtual dispatches.

`beman.any_view.benchmarks.all` results for `eager` vs. `fused`:
```
Comparing eager (from build/tests/beman/any_view/beman.any_view.benchmarks.all) to fused (from build/tests/beman/any_view/beman.any_view.benchmarks.all)
Benchmark                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------
BM_all_[eager vs. fused]/1024                  -0.1209         -0.1210          1781          1566          1781          1566
BM_all_[eager vs. fused]/2048                  -0.1343         -0.1343          3378          2924          3378          2924
BM_all_[eager vs. fused]/4096                  -0.1424         -0.1424          7511          6441          7511          6441
BM_all_[eager vs. fused]/8192                  -0.5492         -0.5492         30474         13737         30474         13737
BM_all_[eager vs. fused]/16384                 +0.2556         +0.2556         23969         30096         23969         30096
BM_all_[eager vs. fused]/32768                 -0.1259         -0.1259         70983         62043         70982         62043
BM_all_[eager vs. fused]/65536                 -0.2647         -0.2648        177906        130806        177906        130805
BM_all_[eager vs. fused]/131072                -0.3002         -0.3002        379812        265803        379810        265802
BM_all_[eager vs. fused]/262144                -0.3267         -0.3268        828085        557555        828073        557458
OVERALL_GEOMEAN                                -0.2160         -0.2160
```
Overall, a net improvement. The timing of a specific run depends on how many reallocations vector needed to store the results, but `any_view` provides more consistent and predictable performance which is ideal for realtime or low latency systems.

Given the relative disadvantage being predicated to reallocations, I thought to add another benchmark `reserved` using a pre-allocated vector by iterating twice over the products.

`beman.any_view.benchmarks.all` results for `eager` vs. `reserved`:
```
Comparing eager (from build/tests/beman/any_view/beman.any_view.benchmarks.all) to reserved (from build/tests/beman/any_view/beman.any_view.benchmarks.all)
Benchmark                                            Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------------------
BM_all_[eager vs. reserved]/1024                  -0.0563         -0.0563          1888          1782          1888          1782
BM_all_[eager vs. reserved]/2048                  +0.0626         +0.0626          3294          3500          3294          3500
BM_all_[eager vs. reserved]/4096                  +0.0807         +0.0807          6721          7263          6721          7263
BM_all_[eager vs. reserved]/8192                  -0.5694         -0.5694         32452         13972         32452         13972
BM_all_[eager vs. reserved]/16384                 -0.1381         -0.1381         30686         26448         30686         26448
BM_all_[eager vs. reserved]/32768                 +0.0064         +0.0064         66188         66611         66188         66611
BM_all_[eager vs. reserved]/65536                 -0.0139         -0.0139        166604        164283        166604        164282
BM_all_[eager vs. reserved]/131072                +0.1024         +0.1024        325039        358321        325038        358319
BM_all_[eager vs. reserved]/262144                +0.0036         +0.0036        795072        797937        795067        797930
OVERALL_GEOMEAN                                   -0.0868         -0.0868
```

While this comparison does not involve `any_view` directly, it is important to understand how pre-allocating a vector compares to reallocating as it grows. Because of the significant benefit in specific cases, it does provide an overall net improvement to the naive `eager` approach.

Now let's compare this to `fused`:

`beman.any_view.benchmarks.all` results for `reserved` vs. `fused`:
```
Comparing reserved (from build/tests/beman/any_view/beman.any_view.benchmarks.all) to fused (from build/tests/beman/any_view/beman.any_view.benchmarks.all)
Benchmark                                            Time             CPU      Time Old      Time New       CPU Old       CPU New
---------------------------------------------------------------------------------------------------------------------------------
BM_all_[reserved vs. fused]/1024                  -0.2007         -0.2007          1806          1444          1806          1444
BM_all_[reserved vs. fused]/2048                  -0.1279         -0.1279          3306          2883          3306          2883
BM_all_[reserved vs. fused]/4096                  -0.0847         -0.0847          6677          6111          6677          6111
BM_all_[reserved vs. fused]/8192                  -0.0081         -0.0081         13837         13725         13837         13725
BM_all_[reserved vs. fused]/16384                 +0.1612         +0.1612         25038         29073         25038         29073
BM_all_[reserved vs. fused]/32768                 +0.0100         +0.0100         61224         61838         61224         61838
BM_all_[reserved vs. fused]/65536                 -0.1279         -0.1279        155911        135973        155911        135972
BM_all_[reserved vs. fused]/131072                -0.1816         -0.1816        321379        263026        321380        263025
BM_all_[reserved vs. fused]/262144                -0.2594         -0.2594        777507        575848        777491        575845
OVERALL_GEOMEAN                                   -0.0987         -0.0987
```
Overall, inconclusive evidence to support either approach over the other. Yes, the overall geometric mean difference shows an improvement of about 9%, but outcomes in specific cases don't follow a clearly visible pattern.

Let's demonstrate where `any_view` *really* shines.

`beman.any_view.benchmarks.take` results for `eager` vs. `fused`:
```
Comparing eager (from build/tests/beman/any_view/beman.any_view.benchmarks.take) to fused (from build/tests/beman/any_view/beman.any_view.benchmarks.take)
Benchmark                                          Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------
BM_take_[eager vs. fused]/1024                  -0.8895         -0.8895          1414           156          1414           156
BM_take_[eager vs. fused]/2048                  -0.9472         -0.9472          2871           152          2871           152
BM_take_[eager vs. fused]/4096                  -0.9740         -0.9740          5851           152          5851           152
BM_take_[eager vs. fused]/8192                  -0.9947         -0.9947         28167           151         28166           151
BM_take_[eager vs. fused]/16384                 -0.9937         -0.9937         24401           153         24401           153
BM_take_[eager vs. fused]/32768                 -0.9970         -0.9970         50478           152         50477           152
BM_take_[eager vs. fused]/65536                 -0.9986         -0.9986        105898           152        105898           152
BM_take_[eager vs. fused]/131072                -0.9993         -0.9993        222263           153        222263           153
BM_take_[eager vs. fused]/262144                -0.9997         -0.9997        525336           151        525331           151
OVERALL_GEOMEAN                                 -0.9945         -0.9945
```
No competition. This demonstrates the pure advantage of `any_view` in cases where lazy iteration is the only sensible design choice.