### PR TITLE
Fix lint

### DIFF
--- a/include/beman/any_view/detail/unique_address.hpp
+++ b/include/beman/any_view/detail/unique_address.hpp
@@ -3,19 +3,21 @@
 #ifndef BEMAN_ANY_VIEW_DETAIL_UNIQUE_ADDRESS_HPP
 #define BEMAN_ANY_VIEW_DETAIL_UNIQUE_ADDRESS_HPP
 
-#if !defined(__has_include)
-#  if __has_include(<beman/any_view/config.hpp>)
-#    include <beman/any_view/config.hpp>
-#  endif
-#else
+#ifdef __has_include
+#if __has_include(<beman/any_view/config.hpp>)
+#include <beman/any_view/config.hpp>
+#endif // __has_include(<beman/any_view/config.hpp>)
+#endif // __has_include
+
 // if the config.hpp file does not exist because this is in godbolt
 // or another context where cmake is not run, default to the correct
 // answer.
-#  if (_MSC_VER)
-#    define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS() [[msvc::no_unique_address]]
-#  else
-#    define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS() [[no_unique_address]]
-#  endif
-#endif
+#ifndef BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS
+#if _MSC_VER
+#define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS() [[msvc::no_unique_address]]
+#else
+#define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS() [[no_unique_address]]
+#endif // _MSC_VER
+#endif // BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS
 
-#endif
+#endif // BEMAN_ANY_VIEW_DETAIL_UNIQUE_ADDRESS_HPP


### PR DESCRIPTION
Also contains bugfix - `#if !defined(__has_include)` caused the fallback to occur when `__has_include` was defined, instead of including `config.hpp`.