### PR TITLE
Add approximately_sized support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ target_sources(
             include/beman/any_view/any_view_options.hpp
             include/beman/any_view/any_view.hpp
             include/beman/any_view/concepts.hpp
+            include/beman/any_view/reserve_hint.hpp
 )
 
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -104,14 +104,15 @@ namespace beman::any_view {
 
 // [range.any]
 enum class any_view_options {
-    input         = 0b00000001,
-    forward       = 0b00000011,
-    bidirectional = 0b00000111,
-    random_access = 0b00001111,
-    contiguous    = 0b00011111,
-    sized         = 0b00100000,
-    borrowed      = 0b01000000,
-    copyable      = 0b10000000,
+    input               = 0b000000001,
+    forward             = 0b000000011,
+    bidirectional       = 0b000000111,
+    random_access       = 0b000001111,
+    contiguous          = 0b000011111,
+    approximately_sized = 0b000100000,
+    sized               = 0b001100000,
+    borrowed            = 0b010000000,
+    copyable            = 0b100000000,
 };
 
 constexpr any_view_options operator|(any_view_options, any_view_options) noexcept;
@@ -161,6 +162,8 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
 
     constexpr std::make_unsigned_t<DiffT> size() const;
 
+    constexpr std::make_unsigned_t<DiffT> reserve_hint() const;
+
     // [range.any.swap]
     constexpr void swap(any_view&) noexcept;
 
@@ -172,7 +175,7 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
 template <class ElementT, beman::any_view::any_view_options OptsV, class RefT, class RValueRefT, class DiffT>
 inline constexpr bool std::ranges::enable_borrowed_range<
     beman::any_view::any_view<ElementT, OptsV, RefT, RValueRefT, DiffT>> =
-        bool(OptsV & beman::any_view::any_view_options::borrowed);
+        (OptsV & beman::any_view::any_view_options::borrowed) == beman::any_view::any_view_options::borrowed;
 ```
 
 </details>

--- a/include/beman/any_view/any_view.hpp
+++ b/include/beman/any_view/any_view.hpp
@@ -14,7 +14,7 @@ template <class ElementT,
           class RValueRefT       = detail::rvalue_ref_t<RefT>,
           class DiffT            = std::ptrdiff_t>
 class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, RefT, RValueRefT, DiffT>> {
-    static_assert(bool(OptsV & any_view_options::input), "any_view must model input_range");
+    static_assert((OptsV & any_view_options::input) == any_view_options::input, "any_view must model input_range");
 
     using iterator_concept = decltype(detail::get_iter_concept<OptsV>());
     using iterator         = detail::any_iterator<iterator_concept, ElementT, RefT, RValueRefT, DiffT>;
@@ -42,13 +42,13 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
     constexpr any_view() noexcept : any_view(detail::default_view<ElementT, RefT, RValueRefT, DiffT>{}) {}
 
     constexpr any_view(const any_view&)
-        requires(bool(OptsV& any_view_options::copyable))
+        requires((OptsV & any_view_options::copyable) == any_view_options::copyable)
     = default;
 
     constexpr any_view(any_view&& other) noexcept : any_view() { swap(other); }
 
     constexpr any_view& operator=(const any_view&)
-        requires(bool(OptsV& any_view_options::copyable))
+        requires((OptsV & any_view_options::copyable) == any_view_options::copyable)
     = default;
 
     constexpr any_view& operator=(any_view&& other) noexcept {
@@ -66,9 +66,15 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
     [[nodiscard]] constexpr sentinel end() { return std::default_sentinel; }
 
     [[nodiscard]] constexpr size_type size() const
-        requires(bool(OptsV& any_view_options::sized))
+        requires((OptsV & any_view_options::sized) == any_view_options::sized)
     {
         return view_ptr->size();
+    }
+
+    [[nodiscard]] constexpr size_type reserve_hint() const
+        requires((OptsV & any_view_options::approximately_sized) == any_view_options::approximately_sized)
+    {
+        return view_ptr->reserve_hint();
     }
 
     // [range.any.swap]
@@ -82,6 +88,6 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
 template <class ElementT, beman::any_view::any_view_options OptsV, class RefT, class RValueRefT, class DiffT>
 inline constexpr bool
     std::ranges::enable_borrowed_range<beman::any_view::any_view<ElementT, OptsV, RefT, RValueRefT, DiffT>> =
-        bool(OptsV & beman::any_view::any_view_options::borrowed);
+        (OptsV & beman::any_view::any_view_options::borrowed) == beman::any_view::any_view_options::borrowed;
 
 #endif // BEMAN_ANY_VIEW_ANY_VIEW_HPP

--- a/include/beman/any_view/any_view_options.hpp
+++ b/include/beman/any_view/any_view_options.hpp
@@ -6,14 +6,15 @@
 namespace beman::any_view {
 
 enum class any_view_options {
-    input         = 0b00000001,
-    forward       = 0b00000011,
-    bidirectional = 0b00000111,
-    random_access = 0b00001111,
-    contiguous    = 0b00011111,
-    sized         = 0b00100000,
-    borrowed      = 0b01000000,
-    copyable      = 0b10000000,
+    input               = 0b000000001,
+    forward             = 0b000000011,
+    bidirectional       = 0b000000111,
+    random_access       = 0b000001111,
+    contiguous          = 0b000011111,
+    approximately_sized = 0b000100000,
+    sized               = 0b001100000,
+    borrowed            = 0b010000000,
+    copyable            = 0b100000000,
 };
 
 [[nodiscard]] constexpr any_view_options operator|(any_view_options l, any_view_options r) noexcept {

--- a/include/beman/any_view/concepts.hpp
+++ b/include/beman/any_view/concepts.hpp
@@ -5,6 +5,7 @@
 
 #include <beman/any_view/detail/concepts.hpp>
 #include <beman/any_view/detail/type_traits.hpp>
+#include <beman/any_view/reserve_hint.hpp>
 
 #include <ranges>
 
@@ -21,7 +22,12 @@ concept any_compatible_iterator =
     std::convertible_to<std::iter_difference_t<IteratorT>, std::iter_difference_t<AnyIteratorT>>;
 
 template <class RangeT, class AnyViewT>
-concept any_compatible_sized_range = not std::ranges::sized_range<AnyViewT> or std::ranges::sized_range<RangeT>;
+concept any_compatible_approximately_sized_range =
+    not approximately_sized_range<AnyViewT> or approximately_sized_range<RangeT>;
+
+template <class RangeT, class AnyViewT>
+concept any_compatible_sized_range = any_compatible_approximately_sized_range<RangeT, AnyViewT> and
+                                     (not std::ranges::sized_range<AnyViewT> or std::ranges::sized_range<RangeT>);
 
 template <class RangeT, class AnyViewT>
 concept any_compatible_borrowed_range =

--- a/include/beman/any_view/detail/any_iterator.hpp
+++ b/include/beman/any_view/detail/any_iterator.hpp
@@ -10,8 +10,26 @@
 
 namespace beman::any_view::detail {
 
+template <class IterConceptT, bool IsRefV>
+struct iterator_category_type {
+    using iterator_category = std::input_iterator_tag;
+};
+
+template <bool IsRefV>
+struct iterator_category_type<std::input_iterator_tag, IsRefV> {};
+
+template <std::derived_from<std::forward_iterator_tag> IterConceptT>
+struct iterator_category_type<IterConceptT, true> {
+    using iterator_category = IterConceptT;
+};
+
+template <>
+struct iterator_category_type<std::contiguous_iterator_tag, true> {
+    using iterator_category = std::random_access_iterator_tag;
+};
+
 template <class IterConceptT, class ElementT, class RefT, class RValueRefT, class DiffT>
-class any_iterator {
+class any_iterator : public iterator_category_type<IterConceptT, std::is_reference_v<RefT>> {
     using reference        = RefT;
     using rvalue_reference = RValueRefT;
     using pointer          = std::add_pointer_t<RefT>;
@@ -39,7 +57,7 @@ class any_iterator {
 
   public:
     using iterator_concept = IterConceptT;
-    using element_type     = ElementT;
+    using value_type       = std::remove_cv_t<ElementT>;
     using difference_type  = DiffT;
 
     template <detail::any_compatible_iterator<any_iterator> IteratorT, std::sentinel_for<IteratorT> SentinelT>

--- a/include/beman/any_view/detail/view_adaptor.hpp
+++ b/include/beman/any_view/detail/view_adaptor.hpp
@@ -5,6 +5,7 @@
 
 #include <beman/any_view/detail/unique_address.hpp>
 #include <beman/any_view/detail/view_interface.hpp>
+#include <beman/any_view/reserve_hint.hpp>
 
 namespace beman::any_view::detail {
 
@@ -59,6 +60,14 @@ class view_adaptor final : public view_interface<IterConceptT, ElementT, RefT, R
     [[nodiscard]] constexpr auto size() const -> size_type override {
         if constexpr (std::ranges::sized_range<ViewT>) {
             return std::ranges::size(view);
+        } else {
+            unreachable();
+        }
+    }
+
+    [[nodiscard]] constexpr auto reserve_hint() const -> size_type override {
+        if constexpr (beman::any_view::approximately_sized_range<ViewT>) {
+            return beman::any_view::reserve_hint(view);
         } else {
             unreachable();
         }

--- a/include/beman/any_view/detail/view_interface.hpp
+++ b/include/beman/any_view/detail/view_interface.hpp
@@ -25,6 +25,8 @@ class view_interface {
 
     [[nodiscard]] virtual constexpr auto size() const -> size_type = 0;
 
+    [[nodiscard]] virtual constexpr auto reserve_hint() const -> size_type = 0;
+
     virtual constexpr ~view_interface() noexcept = default;
 };
 

--- a/include/beman/any_view/reserve_hint.hpp
+++ b/include/beman/any_view/reserve_hint.hpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <ranges>
+
+#ifndef BEMAN_ANY_VIEW_RESERVE_HINT_HPP
+#define BEMAN_ANY_VIEW_RESERVE_HINT_HPP
+
+namespace beman::any_view {
+namespace detail {
+
+template <class T>
+    requires std::convertible_to<T, std::decay_t<T>>
+std::decay_t<T> decay_copy(T&& value) noexcept(std::is_nothrow_convertible_v<T, std::decay_t<T>>);
+
+// TODO: implement and use is-integer-like instead of std::integral
+
+template <class T>
+concept member_reserve_hint = requires(T& t) {
+    { decay_copy(t.reserve_hint()) } -> std::integral;
+};
+
+// force argument dependent lookup by failing unqualified name lookup
+void reserve_hint() = delete;
+
+template <class T>
+concept adl_reserve_hint = requires(T& t) {
+    { decay_copy(reserve_hint(t)) } -> std::integral;
+};
+
+struct reserve_hint_cpo {
+  private:
+    template <class T>
+    static constexpr bool is_noexcept() {
+        if constexpr (std::ranges::sized_range<T>) {
+            return noexcept(std::ranges::size(std::declval<T&>()));
+        } else if constexpr (member_reserve_hint<T>) {
+            return noexcept(decay_copy(std::declval<T&>().reserve_hint()));
+        } else if constexpr (adl_reserve_hint<T>) {
+            return noexcept(decay_copy(reserve_hint(std::declval<T&>())));
+        } else {
+            return false;
+        }
+    }
+
+  public:
+    template <class T>
+        requires std::ranges::sized_range<T> or member_reserve_hint<T> or adl_reserve_hint<T>
+    [[nodiscard]] constexpr auto operator()(T&& t) const noexcept(is_noexcept<T&>()) {
+        if constexpr (std::ranges::sized_range<T>) {
+            return std::ranges::size(t);
+        } else if constexpr (member_reserve_hint<T>) {
+            return t.reserve_hint();
+        } else if constexpr (adl_reserve_hint<T>) {
+            return reserve_hint(t);
+        }
+    }
+};
+
+} // namespace detail
+
+inline constexpr detail::reserve_hint_cpo reserve_hint{};
+
+template <class T>
+concept approximately_sized_range =
+    std::ranges::range<T> and
+    // use disjunction with std::ranges::sized_range so it subsumes beman::any_view::approximately_sized_range
+    (std::ranges::sized_range<T> or requires(T& t) { beman::any_view::reserve_hint(t); });
+
+} // namespace beman::any_view
+
+#endif // BEMAN_ANY_VIEW_RESERVE_HINT_HPP

--- a/tests/beman/any_view/concepts.test.cpp
+++ b/tests/beman/any_view/concepts.test.cpp
@@ -20,14 +20,28 @@ TEST(ConceptsTest, iterator_concept) {
     static_assert(not std::ranges::contiguous_range<any_view<int, random_access>>);
     static_assert(std::ranges::contiguous_range<any_view<int, contiguous>>);
 
+    static_assert(std::ranges::input_range<any_view<int, input | approximately_sized>>);
+    static_assert(not std::ranges::forward_range<any_view<int, input | approximately_sized>>);
     static_assert(std::ranges::input_range<any_view<int, input | sized>>);
     static_assert(not std::ranges::forward_range<any_view<int, input | sized>>);
     static_assert(std::ranges::input_range<any_view<int, input | borrowed>>);
     static_assert(not std::ranges::forward_range<any_view<int, input | borrowed>>);
-    static_assert(std::ranges::input_range<any_view<int, input | borrowed>>);
-    static_assert(not std::ranges::forward_range<any_view<int, input | borrowed>>);
     static_assert(std::ranges::input_range<any_view<int, input | copyable>>);
     static_assert(not std::ranges::forward_range<any_view<int, input | copyable>>);
+}
+
+TEST(ConceptsTest, approximately_sized_concept) {
+    static_assert(not beman::any_view::approximately_sized_range<any_view<int>>);
+    static_assert(beman::any_view::approximately_sized_range<any_view<int, input | approximately_sized>>);
+    static_assert(beman::any_view::approximately_sized_range<any_view<int, input | sized>>);
+
+    static_assert(not beman::any_view::approximately_sized_range<any_view<int, input>>);
+    static_assert(not beman::any_view::approximately_sized_range<any_view<int, forward>>);
+    static_assert(not beman::any_view::approximately_sized_range<any_view<int, bidirectional>>);
+    static_assert(not beman::any_view::approximately_sized_range<any_view<int, random_access>>);
+    static_assert(not beman::any_view::approximately_sized_range<any_view<int, contiguous>>);
+    static_assert(not beman::any_view::approximately_sized_range<any_view<int, input | borrowed>>);
+    static_assert(not beman::any_view::approximately_sized_range<any_view<int, input | copyable>>);
 }
 
 TEST(ConceptsTest, sized_concept) {
@@ -39,6 +53,7 @@ TEST(ConceptsTest, sized_concept) {
     static_assert(not std::ranges::sized_range<any_view<int, bidirectional>>);
     static_assert(not std::ranges::sized_range<any_view<int, random_access>>);
     static_assert(not std::ranges::sized_range<any_view<int, contiguous>>);
+    static_assert(not std::ranges::sized_range<any_view<int, input | approximately_sized>>);
     static_assert(not std::ranges::sized_range<any_view<int, input | borrowed>>);
     static_assert(not std::ranges::sized_range<any_view<int, input | copyable>>);
 }
@@ -52,6 +67,7 @@ TEST(ConceptsTest, borrowed_concept) {
     static_assert(not std::ranges::borrowed_range<any_view<int, bidirectional>>);
     static_assert(not std::ranges::borrowed_range<any_view<int, random_access>>);
     static_assert(not std::ranges::borrowed_range<any_view<int, contiguous>>);
+    static_assert(not std::ranges::borrowed_range<any_view<int, input | approximately_sized>>);
     static_assert(not std::ranges::borrowed_range<any_view<int, input | sized>>);
     static_assert(not std::ranges::borrowed_range<any_view<int, input | copyable>>);
 }
@@ -65,6 +81,7 @@ TEST(ConceptsTest, copyable_concept) {
     static_assert(not std::copyable<any_view<int, bidirectional>>);
     static_assert(not std::copyable<any_view<int, random_access>>);
     static_assert(not std::copyable<any_view<int, contiguous>>);
+    static_assert(not std::copyable<any_view<int, input | approximately_sized>>);
     static_assert(not std::copyable<any_view<int, input | sized>>);
     static_assert(not std::copyable<any_view<int, input | borrowed>>);
 }

--- a/tests/beman/any_view/sfinae.test.cpp
+++ b/tests/beman/any_view/sfinae.test.cpp
@@ -15,6 +15,8 @@ TEST(SfinaeTest, istream_view) {
     static_assert(std::constructible_from<any_view<int, input>, std::ranges::istream_view<int>>);
     static_assert(not std::constructible_from<any_view<int, forward>, std::ranges::istream_view<int>>);
     static_assert(std::constructible_from<any_view<int, input | copyable>, std::ranges::istream_view<int>>);
+    static_assert(
+        not std::constructible_from<any_view<int, input | approximately_sized>, std::ranges::istream_view<int>>);
     static_assert(not std::constructible_from<any_view<int, input | sized>, std::ranges::istream_view<int>>);
     static_assert(not std::constructible_from<any_view<int, input | borrowed>, std::ranges::istream_view<int>>);
 
@@ -26,6 +28,7 @@ TEST(SfinaeTest, istream_view) {
 TEST(SfinaeTest, forward_list) {
     static_assert(std::constructible_from<any_view<int, forward>, std::forward_list<int>>);
     static_assert(not std::constructible_from<any_view<int, bidirectional>, std::forward_list<int>>);
+    static_assert(not std::constructible_from<any_view<int, input | approximately_sized>, std::forward_list<int>>);
     static_assert(not std::constructible_from<any_view<int, input | sized>, std::forward_list<int>>);
     static_assert(not std::constructible_from<any_view<int, input | borrowed>, std::forward_list<int>>);
     static_assert(not std::constructible_from<any_view<int, input | copyable>, std::forward_list<int>>);
@@ -37,6 +40,7 @@ TEST(SfinaeTest, forward_list) {
 TEST(SfinaeTest, list) {
     static_assert(std::constructible_from<any_view<int, bidirectional>, std::list<int>>);
     static_assert(not std::constructible_from<any_view<int, random_access>, std::list<int>>);
+    static_assert(std::constructible_from<any_view<int, input | approximately_sized>, std::list<int>>);
     static_assert(std::constructible_from<any_view<int, input | sized>, std::list<int>>);
     static_assert(not std::constructible_from<any_view<int, input | borrowed>, std::list<int>>);
     static_assert(not std::constructible_from<any_view<int, input | copyable>, std::list<int>>);
@@ -48,6 +52,7 @@ TEST(SfinaeTest, list) {
 TEST(SfinaeTest, deque) {
     static_assert(std::constructible_from<any_view<int, random_access>, std::deque<int>>);
     static_assert(not std::constructible_from<any_view<int, contiguous>, std::deque<int>>);
+    static_assert(std::constructible_from<any_view<int, input | approximately_sized>, std::deque<int>>);
     static_assert(std::constructible_from<any_view<int, input | sized>, std::deque<int>>);
     static_assert(not std::constructible_from<any_view<int, input | borrowed>, std::deque<int>>);
     static_assert(not std::constructible_from<any_view<int, input | copyable>, std::deque<int>>);
@@ -58,6 +63,7 @@ TEST(SfinaeTest, deque) {
 
 TEST(SfinaeTest, vector) {
     static_assert(std::constructible_from<any_view<int, contiguous>, std::vector<int>>);
+    static_assert(std::constructible_from<any_view<int, input | approximately_sized>, std::vector<int>>);
     static_assert(std::constructible_from<any_view<int, input | sized>, std::vector<int>>);
     static_assert(not std::constructible_from<any_view<int, input | borrowed>, std::vector<int>>);
     static_assert(not std::constructible_from<any_view<int, input | copyable>, std::vector<int>>);
@@ -68,6 +74,7 @@ TEST(SfinaeTest, vector) {
 
 TEST(SfinaeTest, vector_of_bool) {
     static_assert(std::constructible_from<any_view<bool, random_access, bool>, std::vector<bool>>);
+    static_assert(std::constructible_from<any_view<bool, input | approximately_sized, bool>, std::vector<bool>>);
     static_assert(std::constructible_from<any_view<bool, input | sized, bool>, std::vector<bool>>);
     static_assert(not std::constructible_from<any_view<bool, input | borrowed, bool>, std::vector<bool>>);
     static_assert(not std::constructible_from<any_view<bool, input | copyable, bool>, std::vector<bool>>);
@@ -78,6 +85,7 @@ TEST(SfinaeTest, vector_of_bool) {
 
 TEST(SfinaeTest, span) {
     static_assert(std::constructible_from<any_view<int, contiguous>, std::span<int>>);
+    static_assert(std::constructible_from<any_view<int, input | approximately_sized>, std::span<int>>);
     static_assert(std::constructible_from<any_view<int, input | sized>, std::span<int>>);
     static_assert(std::constructible_from<any_view<int, input | borrowed>, std::span<int>>);
     static_assert(std::constructible_from<any_view<int, input | copyable>, std::span<int>>);


### PR DESCRIPTION
New `approximately_sized` option added in R5 requires implementation of `std::ranges::reserve_hint` and `std::ranges::approximately_sized_range`, which have been added to the `beman::any_view` namespace here.