### PR TITLE
Remove subrange from default_view

### DIFF
--- a/include/beman/any_view/detail/default_iterator.hpp
+++ b/include/beman/any_view/detail/default_iterator.hpp
@@ -6,60 +6,53 @@
 #include <beman/any_view/detail/unreachable.hpp>
 
 #include <compare>
-#include <concepts>
 #include <iterator>
 
 namespace beman::any_view::detail {
 
 template <class ElementT, class RefT, class RValueRefT, class DiffT>
-struct iterator_concept {
-    using type = std::random_access_iterator_tag;
-};
-
-template <class ElementT>
-struct iterator_concept<ElementT, ElementT&, ElementT&&, std::ptrdiff_t> {
-    using type = std::contiguous_iterator_tag;
-};
-
-template <class ElementT, class RefT, class RValueRefT, class DiffT>
 class default_iterator {
   public:
-    using iterator_concept = typename iterator_concept<ElementT, RefT, RValueRefT, DiffT>::type;
+    using iterator_concept = std::contiguous_iterator_tag;
     using element_type     = ElementT;
 
-    constexpr RefT operator*() const noexcept { unreachable(); }
+    RefT operator*() const noexcept { unreachable(); }
 
-    constexpr friend RValueRefT iter_move(default_iterator) noexcept { unreachable(); }
+    friend RValueRefT iter_move(default_iterator) noexcept { unreachable(); }
 
-    constexpr default_iterator& operator++() noexcept { unreachable(); }
+    default_iterator& operator++() noexcept { unreachable(); }
 
-    constexpr default_iterator operator++(int) noexcept { unreachable(); }
+    default_iterator operator++(int) noexcept { unreachable(); }
+
+    constexpr bool operator==(std::default_sentinel_t) const noexcept { return true; }
+
+    constexpr bool operator==(const default_iterator&) const noexcept = default;
 
     constexpr std::strong_ordering operator<=>(const default_iterator&) const noexcept = default;
 
-    constexpr default_iterator& operator--() noexcept { unreachable(); }
+    default_iterator& operator--() noexcept { unreachable(); }
 
-    constexpr default_iterator operator--(int) noexcept { unreachable(); }
+    default_iterator operator--(int) noexcept { unreachable(); }
+
+    constexpr DiffT operator-(std::default_sentinel_t) const noexcept { return 0; }
+
+    constexpr friend DiffT operator-(std::default_sentinel_t, default_iterator) noexcept { return 0; }
 
     constexpr DiffT operator-(default_iterator) const noexcept { return 0; }
 
-    constexpr default_iterator& operator+=(DiffT) noexcept { unreachable(); }
+    default_iterator& operator+=(DiffT) noexcept { unreachable(); }
 
-    constexpr default_iterator operator+(DiffT) const noexcept { unreachable(); }
+    default_iterator operator+(DiffT) const noexcept { unreachable(); }
 
-    constexpr friend default_iterator operator+(DiffT, default_iterator) noexcept { unreachable(); }
+    friend default_iterator operator+(DiffT, default_iterator) noexcept { unreachable(); }
 
-    constexpr default_iterator& operator-=(DiffT) noexcept { unreachable(); }
+    default_iterator& operator-=(DiffT) noexcept { unreachable(); }
 
-    constexpr default_iterator operator-(DiffT) const noexcept { unreachable(); }
+    default_iterator operator-(DiffT) const noexcept { unreachable(); }
 
-    constexpr RefT operator[](DiffT) const noexcept { unreachable(); }
+    RefT operator[](DiffT) const noexcept { unreachable(); }
 
-    constexpr element_type* operator->() const noexcept
-        requires std::derived_from<iterator_concept, std::contiguous_iterator_tag>
-    {
-        return nullptr;
-    }
+    constexpr element_type* operator->() const noexcept { return nullptr; }
 };
 
 } // namespace beman::any_view::detail

--- a/include/beman/any_view/detail/default_view.hpp
+++ b/include/beman/any_view/detail/default_view.hpp
@@ -4,7 +4,6 @@
 #define BEMAN_ANY_VIEW_DETAIL_DEFAULT_VIEW_HPP
 
 #include <beman/any_view/detail/default_iterator.hpp>
-#include <beman/any_view/detail/no_unique_address.hpp>
 
 #include <ranges>
 
@@ -13,11 +12,11 @@ namespace beman::any_view::detail {
 template <class ElementT, class RefT, class RValueRefT, class DiffT>
 class default_view : public std::ranges::view_interface<default_view<ElementT, RefT, RValueRefT, DiffT>> {
     using iterator = default_iterator<ElementT, RefT, RValueRefT, DiffT>;
-    BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS std::ranges::subrange<iterator> view;
+    using sentinel = std::default_sentinel_t;
 
   public:
-    [[nodiscard]] constexpr iterator begin() const { return view.begin(); }
-    [[nodiscard]] constexpr iterator end() const { return view.end(); }
+    [[nodiscard]] constexpr iterator begin() const { return {}; }
+    [[nodiscard]] constexpr sentinel end() const { return std::default_sentinel; }
 };
 
 } // namespace beman::any_view::detail


### PR DESCRIPTION
Reduce complexity of `default_view` by removing `subrange` from it, and remove `constexpr` from unreachable member functions of `default_iterator`.