### PR TITLE
Add tagged default constructor to polymorphic

### DIFF
--- a/include/beman/any_view/any_view.hpp
+++ b/include/beman/any_view/any_view.hpp
@@ -59,12 +59,14 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
     template <detail::capability CapabilityT>
     static constexpr auto dispatch = detail::dispatch<CapabilityT, polymorphic_type>;
 
-    polymorphic_type poly;
+    template <std::ranges::view ViewT>
+    using adaptor_for = detail::view_adaptor<ViewT, OptsV>;
+
+    polymorphic_type poly{std::in_place_type<adaptor_for<detail::default_view<ElementT, RefT, RValueRefT, DiffT>>>};
 
     template <class RangeT, bool IsAnyView>
     constexpr any_view(RangeT&& range, std::bool_constant<IsAnyView>)
-        : poly(detail::view_adaptor<std::views::all_t<RangeT>, OptsV>{
-              .view = std::views::all(std::forward<RangeT>(range))}) {}
+        : poly(adaptor_for<std::views::all_t<RangeT>>{.view = std::views::all(std::forward<RangeT>(range))}) {}
 
     template <class RangeT>
     static consteval bool is_noexcept() {
@@ -92,13 +94,13 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
         }
     }
 
-    constexpr any_view() noexcept : any_view(detail::default_view<ElementT, RefT, RValueRefT, DiffT>{}) {}
+    constexpr any_view() noexcept = default;
 
     constexpr any_view(const any_view&)
         requires copyable
     = default;
 
-    constexpr any_view(any_view&& other) noexcept : any_view() { swap(other); }
+    constexpr any_view(any_view&& other) noexcept { swap(other); }
 
     constexpr any_view& operator=(const any_view&)
         requires copyable
@@ -116,18 +118,16 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
         using capability_type     = detail::iterator_capabilities<RefT, RValueRefT, DiffT, OptsV>;
         using derived_vtable_type = detail::vtable<capability_type, detail::iterator_storage>;
 
-        const auto get_poly = [this] {
-            const auto base_vtable_ptr = dispatch<detail::iterator_vtable_t<RefT, RValueRefT, DiffT>>(poly);
-
-            return detail::polymorphic_iterator<RefT, RValueRefT, DiffT, OptsV>{
-                [this] { return dispatch<detail::begin_t<RefT, RValueRefT, DiffT>>(poly); },
-                static_cast<const derived_vtable_type*>(base_vtable_ptr)};
-        };
+        const auto get_storage = [this] { return dispatch<detail::begin_t<RefT, RValueRefT, DiffT>>(poly); };
+        const auto vtable_ptr  = static_cast<const derived_vtable_type*>(
+            dispatch<detail::iterator_vtable_t<RefT, RValueRefT, DiffT>>(poly));
 
         if constexpr (contiguous_and_sized) {
-            return iterator{std::to_address(uncounted_iterator{get_poly}), static_cast<DiffT>(size())};
+            const auto to_address = &detail::vtable<detail::cache_t<RefT>, detail::iterator_storage>::entry;
+            return iterator{(vtable_ptr->*to_address)(get_storage()), static_cast<DiffT>(size())};
         } else {
-            return iterator{get_poly};
+            return iterator{
+                [=] { return detail::polymorphic_iterator<RefT, RValueRefT, DiffT, OptsV>{get_storage, vtable_ptr}; }};
         }
     }
 

--- a/include/beman/any_view/detail/capabilities.hpp
+++ b/include/beman/any_view/detail/capabilities.hpp
@@ -46,7 +46,7 @@ struct impl<binding<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...) noexcept> {
 template <unary UnaryT, adaptor AdaptorT, storage StorageT, class RetT, class SelfT, class... ArgsT>
 struct impl<binding<UnaryT, AdaptorT>, StorageT, RetT(SelfT&, ArgsT...)> {
     [[nodiscard]] static constexpr RetT fn(SelfT& self, ArgsT... args) {
-        return dispatch<UnaryT, AdaptorT>(unchecked_get<AdaptorT>(self), std::forward<ArgsT>(args)...);
+        return dispatch<UnaryT, AdaptorT>(self.template unchecked_get<AdaptorT>(), std::forward<ArgsT>(args)...);
     }
 };
 
@@ -56,6 +56,8 @@ struct type_t : nullary_capability {
         return typeid(T);
     }
 };
+
+inline constexpr type_t type{};
 
 // bindings for symmetric binary capabilities
 template <symmetric_binary SymmetricBinaryT, adaptor AdaptorT, storage StorageT, class RetT>
@@ -71,7 +73,8 @@ struct impl<binding<SymmetricBinaryT, AdaptorT>,
             return SymmetricBinaryT::default_value();
         }
 
-        return dispatch<SymmetricBinaryT, AdaptorT>(unchecked_get<AdaptorT>(self), unchecked_get<AdaptorT>(other));
+        return dispatch<SymmetricBinaryT, AdaptorT>(self.template unchecked_get<AdaptorT>(),
+                                                    other.template unchecked_get<AdaptorT>());
     }
 };
 
@@ -104,7 +107,7 @@ struct impl<UnaryT, PolyT, RetT(SelfT&, ArgsT...)> {
 template <symmetric_binary SymmetricBinaryT, polymorphic PolyT, class RetT>
 struct impl<SymmetricBinaryT, PolyT, RetT(const PolyT&, const PolyT&)> {
     [[nodiscard]] static constexpr RetT fn(const PolyT& self, const PolyT& other) {
-        return self.entry(SymmetricBinaryT{})(self.get(), other.get(), other.entry(type_t{})());
+        return self.entry(SymmetricBinaryT{})(self.get(), other.get(), other.entry(type)());
     }
 };
 
@@ -120,6 +123,9 @@ struct move_t : nullary_capability {
 };
 
 template <storage StorageT>
+inline constexpr move_t<StorageT> move{};
+
+template <storage StorageT>
 struct copy_t : nullary_capability {
     template <not_adaptor>
     static StorageT fn(const StorageT& source);
@@ -131,15 +137,21 @@ struct copy_t : nullary_capability {
 };
 
 template <storage StorageT>
+inline constexpr copy_t<StorageT> copy{};
+
+template <storage StorageT>
 struct destroy_t : nullary_capability {
     template <not_adaptor>
     static void fn(StorageT& source) noexcept;
 
     template <adaptor AdaptorT>
     static constexpr void fn(StorageT& source) noexcept {
-        destroy_as<AdaptorT>(source);
+        source.template destroy_as<AdaptorT>();
     }
 };
+
+template <storage StorageT>
+inline constexpr destroy_t<StorageT> destroy{};
 
 } // namespace beman::any_view::detail
 

--- a/include/beman/any_view/detail/iterator.hpp
+++ b/include/beman/any_view/detail/iterator.hpp
@@ -69,7 +69,7 @@ class iterator : public iterator_category_type<iterator_concept_t<OptsV>, std::i
     template <capability CapabilityT>
     static constexpr auto dispatch = detail::dispatch<CapabilityT, polymorphic_type>;
 
-    polymorphic_type poly{iterator_adaptor_for<default_view<ElementT, RefT, RValueRefT, DiffT>>{}};
+    polymorphic_type poly{std::in_place_type<iterator_adaptor_for<default_view<ElementT, RefT, RValueRefT, DiffT>>>};
     BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS cache_or_index_type cache_or_index{make_cache_or_index()};
 
     constexpr cache_or_index_type make_cache_or_index() const {

--- a/include/beman/any_view/detail/polymorphic.hpp
+++ b/include/beman/any_view/detail/polymorphic.hpp
@@ -19,15 +19,19 @@ class basic_polymorphic {
 
   public:
     constexpr basic_polymorphic(const basic_polymorphic& other)
-        : storage(other.entry(copy_t<StorageT>{})(other.storage)), vtable_ptrs(other.vtable_ptrs) {}
+        : storage(other.entry(copy<StorageT>)(other.storage)), vtable_ptrs(other.vtable_ptrs) {}
 
     constexpr basic_polymorphic(basic_polymorphic&& other) noexcept
-        : storage(other.entry(move_t<StorageT>{})(std::move(other.storage))), vtable_ptrs(other.vtable_ptrs) {}
+        : storage(other.entry(move<StorageT>)(std::move(other.storage))), vtable_ptrs(other.vtable_ptrs) {}
 
     template <adaptor AdaptorT>
     constexpr basic_polymorphic(AdaptorT&& adaptor)
         : storage(std::forward<AdaptorT>(adaptor)),
           vtable_ptrs(std::addressof(vtable_for<CapabilityTs, StorageT, AdaptorT>)...) {}
+
+    template <adaptor AdaptorT>
+    constexpr basic_polymorphic(std::in_place_type_t<AdaptorT> tag)
+        : storage(tag), vtable_ptrs(std::addressof(vtable_for<CapabilityTs, StorageT, AdaptorT>)...) {}
 
     template <class GetStorageT>
         requires std::is_invocable_r_v<StorageT, GetStorageT>
@@ -38,13 +42,13 @@ class basic_polymorphic {
 
     template <std::derived_from<CapabilityTs>... OtherCapabilityTs>
     constexpr basic_polymorphic(const basic_polymorphic<StorageT, OtherCapabilityTs...>& other)
-        : storage(other.entry(copy_t<StorageT>{})(other.get())), vtable_ptrs(other.entries()) {}
+        : storage(other.entry(copy<StorageT>)(other.get())), vtable_ptrs(other.entries()) {}
 
     template <std::derived_from<CapabilityTs>... OtherCapabilityTs>
     constexpr basic_polymorphic(basic_polymorphic<StorageT, OtherCapabilityTs...>&& other) noexcept
-        : storage(other.entry(move_t<StorageT>{})(std::move(other.get()))), vtable_ptrs(other.entries()) {}
+        : storage(other.entry(move<StorageT>)(std::move(other.get()))), vtable_ptrs(other.entries()) {}
 
-    constexpr ~basic_polymorphic() { entry(destroy_t<StorageT>{})(storage); }
+    constexpr ~basic_polymorphic() { entry(destroy<StorageT>)(storage); }
 
     constexpr basic_polymorphic& operator=(const basic_polymorphic& other) {
         if (this == std::addressof(other)) {

--- a/include/beman/any_view/detail/small_storage.hpp
+++ b/include/beman/any_view/detail/small_storage.hpp
@@ -35,6 +35,14 @@ class small_storage {
     }
 
     template <adaptor AdaptorT>
+    constexpr explicit small_storage(std::in_place_type_t<AdaptorT>) {
+        visit<AdaptorT>(
+            *this,
+            [](inplace_type& inplace) { ::new (&inplace) AdaptorT(); },
+            [](pointer_type& pointer) { std::construct_at(&pointer, ::new AdaptorT()); });
+    }
+
+    template <adaptor AdaptorT>
     constexpr small_storage(const small_storage& other, std::in_place_type_t<AdaptorT>) {
         visit<AdaptorT>(
             *this,
@@ -55,25 +63,25 @@ class small_storage {
     }
 
     template <adaptor AdaptorT>
-    constexpr friend void destroy_as(small_storage& self) noexcept {
+    constexpr void destroy_as() noexcept {
         visit<AdaptorT>(
-            self,
+            *this,
             [](inplace_type& inplace) { reinterpret_cast<AdaptorT&>(inplace).~AdaptorT(); },
             [](pointer_type& pointer) { ::delete static_cast<AdaptorT*>(std::exchange(pointer, nullptr)); });
     }
 
     template <adaptor AdaptorT>
-    [[nodiscard]] constexpr friend AdaptorT& unchecked_get(small_storage& self) {
+    [[nodiscard]] constexpr AdaptorT& unchecked_get() {
         return visit<AdaptorT>(
-            self,
+            *this,
             [](inplace_type& inplace) -> AdaptorT& { return reinterpret_cast<AdaptorT&>(inplace); },
             [](pointer_type& pointer) -> AdaptorT& { return static_cast<AdaptorT&>(*pointer); });
     }
 
     template <adaptor AdaptorT>
-    [[nodiscard]] constexpr friend const AdaptorT& unchecked_get(const small_storage& self) {
+    [[nodiscard]] constexpr const AdaptorT& unchecked_get() const {
         return visit<AdaptorT>(
-            self,
+            *this,
             [](const inplace_type& inplace) -> const AdaptorT& { return reinterpret_cast<const AdaptorT&>(inplace); },
             [](const pointer_type& pointer) -> const AdaptorT& { return static_cast<const AdaptorT&>(*pointer); });
     }


### PR DESCRIPTION
Also:
- Refactor `begin` to elide construction of polymorphic iterator object for contiguous and sized case, instead using storage and vtable objects directly to obtain raw pointer for counted iterator.
- Refactor friend functions `destroy_as` and `unchecked_get` in `small_storage` as member functions to avoid ADL.