### PR TITLE
Inlined code in capabilities to help readability

### DIFF
--- a/include/beman/any_view/detail/capabilities.hpp
+++ b/include/beman/any_view/detail/capabilities.hpp
@@ -57,8 +57,6 @@ struct type_t : nullary_capability {
     }
 };
 
-inline constexpr type_t type{};
-
 // bindings for symmetric binary capabilities
 template <symmetric_binary SymmetricBinaryT, adaptor AdaptorT, storage StorageT, class RetT>
 struct impl<binding<SymmetricBinaryT, AdaptorT>,
@@ -66,7 +64,7 @@ struct impl<binding<SymmetricBinaryT, AdaptorT>,
             RetT(const StorageT&, const StorageT&, const std::type_info&)> {
     [[nodiscard]] static constexpr RetT
     fn(const StorageT& self, const StorageT& other, const std::type_info& other_type) {
-        const auto& self_type = dispatch<type_t, AdaptorT>();
+        const auto& self_type = typeid(AdaptorT);
 
         // std::type_info::operator== is not constexpr until C++23
         if (std::is_constant_evaluated() ? &self_type != &other_type : self_type != other_type) {
@@ -107,7 +105,7 @@ struct impl<UnaryT, PolyT, RetT(SelfT&, ArgsT...)> {
 template <symmetric_binary SymmetricBinaryT, polymorphic PolyT, class RetT>
 struct impl<SymmetricBinaryT, PolyT, RetT(const PolyT&, const PolyT&)> {
     [[nodiscard]] static constexpr RetT fn(const PolyT& self, const PolyT& other) {
-        return self.entry(SymmetricBinaryT{})(self.get(), other.get(), other.entry(type)());
+        return self.entry(SymmetricBinaryT{})(self.get(), other.get(), other.entry(type_t{})());
     }
 };
 
@@ -123,9 +121,6 @@ struct move_t : nullary_capability {
 };
 
 template <storage StorageT>
-inline constexpr move_t<StorageT> move{};
-
-template <storage StorageT>
 struct copy_t : nullary_capability {
     template <not_adaptor>
     static StorageT fn(const StorageT& source);
@@ -137,9 +132,6 @@ struct copy_t : nullary_capability {
 };
 
 template <storage StorageT>
-inline constexpr copy_t<StorageT> copy{};
-
-template <storage StorageT>
 struct destroy_t : nullary_capability {
     template <not_adaptor>
     static void fn(StorageT& source) noexcept;
@@ -149,9 +141,6 @@ struct destroy_t : nullary_capability {
         source.template destroy_as<AdaptorT>();
     }
 };
-
-template <storage StorageT>
-inline constexpr destroy_t<StorageT> destroy{};
 
 } // namespace beman::any_view::detail
 

--- a/include/beman/any_view/detail/polymorphic.hpp
+++ b/include/beman/any_view/detail/polymorphic.hpp
@@ -19,10 +19,10 @@ class basic_polymorphic {
 
   public:
     constexpr basic_polymorphic(const basic_polymorphic& other)
-        : storage(other.entry(copy<StorageT>)(other.storage)), vtable_ptrs(other.vtable_ptrs) {}
+        : storage(other.entry(copy_t<StorageT>{})(other.storage)), vtable_ptrs(other.vtable_ptrs) {}
 
     constexpr basic_polymorphic(basic_polymorphic&& other) noexcept
-        : storage(other.entry(move<StorageT>)(std::move(other.storage))), vtable_ptrs(other.vtable_ptrs) {}
+        : storage(other.entry(move_t<StorageT>{})(std::move(other.storage))), vtable_ptrs(other.vtable_ptrs) {}
 
     template <adaptor AdaptorT>
     constexpr basic_polymorphic(AdaptorT&& adaptor)
@@ -42,13 +42,13 @@ class basic_polymorphic {
 
     template <std::derived_from<CapabilityTs>... OtherCapabilityTs>
     constexpr basic_polymorphic(const basic_polymorphic<StorageT, OtherCapabilityTs...>& other)
-        : storage(other.entry(copy<StorageT>)(other.get())), vtable_ptrs(other.entries()) {}
+        : storage(other.entry(copy_t<StorageT>{})(other.get())), vtable_ptrs(other.entries()) {}
 
     template <std::derived_from<CapabilityTs>... OtherCapabilityTs>
     constexpr basic_polymorphic(basic_polymorphic<StorageT, OtherCapabilityTs...>&& other) noexcept
-        : storage(other.entry(move<StorageT>)(std::move(other.get()))), vtable_ptrs(other.entries()) {}
+        : storage(other.entry(move_t<StorageT>{})(std::move(other.get()))), vtable_ptrs(other.entries()) {}
 
-    constexpr ~basic_polymorphic() { entry(destroy<StorageT>)(storage); }
+    constexpr ~basic_polymorphic() { entry(destroy_t<StorageT>{})(storage); }
 
     constexpr basic_polymorphic& operator=(const basic_polymorphic& other) {
         if (this == std::addressof(other)) {

--- a/include/beman/any_view/detail/polymorphic_iterator.hpp
+++ b/include/beman/any_view/detail/polymorphic_iterator.hpp
@@ -66,11 +66,11 @@ struct cache_t : unary_capability {
 
     template <adaptor IteratorAdaptorT>
     [[nodiscard]] static constexpr iter_cache_t<RefT> fn(const IteratorAdaptorT& adaptor) {
-        if (dispatch<sentinel_compare_t, IteratorAdaptorT>(adaptor)) {
+        if (adaptor.iterator == adaptor.sentinel) {
             return {};
         }
 
-        return iter_cache<RefT>::make(dispatch<dereference_t<RefT>, IteratorAdaptorT>(adaptor));
+        return iter_cache<RefT>::make(*adaptor.iterator);
     }
 };
 
@@ -91,7 +91,7 @@ struct next_t : unary_capability {
 
     template <adaptor IteratorAdaptorT>
     [[nodiscard]] static constexpr iter_cache_t<RefT> fn(IteratorAdaptorT& adaptor) {
-        dispatch<increment_t, IteratorAdaptorT>(adaptor);
+        ++adaptor.iterator;
         return dispatch<cache_t<RefT>, IteratorAdaptorT>(adaptor);
     }
 };
@@ -113,7 +113,7 @@ struct prev_t : unary_capability {
 
     template <adaptor IteratorAdaptorT>
     [[nodiscard]] static constexpr iter_cache_t<RefT> fn(IteratorAdaptorT& adaptor) {
-        dispatch<decrement_t, IteratorAdaptorT>(adaptor);
+        --adaptor.iterator;
         return dispatch<cache_t<RefT>, IteratorAdaptorT>(adaptor);
     }
 };
@@ -192,15 +192,7 @@ struct three_way_compare_t : symmetric_binary_capability {
     template <adaptor IteratorAdaptorT>
     [[nodiscard]] static constexpr std::partial_ordering fn(const IteratorAdaptorT& adaptor,
                                                             const IteratorAdaptorT& other) {
-        // std::__wrap_iter is not three-way comparable in Apple Clang
-        if constexpr (std::three_way_comparable<decltype(adaptor.iterator)>) {
-            return adaptor.iterator <=> other.iterator;
-        } else {
-            return adaptor.iterator < other.iterator    ? std::partial_ordering::less
-                   : adaptor.iterator > other.iterator  ? std::partial_ordering::greater
-                   : adaptor.iterator == other.iterator ? std::partial_ordering::equivalent
-                                                        : std::partial_ordering::unordered;
-        }
+        return std::compare_partial_order_fallback(adaptor.iterator, other.iterator);
     }
 };
 


### PR DESCRIPTION
In retrospect, DRY can make these capabilities harder to read, and can also force the compiler to do more work in order to inline code.