### PR TITLE
Optimized const-conversion based on as_const_view

### DIFF
--- a/include/beman/any_view/any_view.hpp
+++ b/include/beman/any_view/any_view.hpp
@@ -10,9 +10,6 @@
 namespace beman::any_view {
 namespace detail {
 
-template <class>
-struct is_any_view : std::false_type {};
-
 template <class T>
 struct rvalue_ref {
     using type = T;
@@ -52,7 +49,8 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
     using uncounted_iterator = detail::iterator<ElementT, RefT, RValueRefT, DiffT, OptsV>;
     using iterator =
         std::conditional_t<contiguous_and_sized, std::counted_iterator<std::add_pointer_t<RefT>>, uncounted_iterator>;
-    using polymorphic_type = detail::polymorphic_view<RefT, RValueRefT, DiffT, OptsV>;
+    using value_type       = std::remove_cv_t<ElementT>;
+    using polymorphic_type = detail::polymorphic_view<value_type, RefT, RValueRefT, DiffT, OptsV>;
     using sentinel         = std::default_sentinel_t;
     using size_type        = std::make_unsigned_t<DiffT>;
 
@@ -62,31 +60,93 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
     template <std::ranges::view ViewT>
     using adaptor_for = detail::view_adaptor<ViewT, OptsV>;
 
-    polymorphic_type poly{std::in_place_type<adaptor_for<detail::default_view<ElementT, RefT, RValueRefT, DiffT>>>};
-
-    template <class RangeT, bool IsAnyView>
-    constexpr any_view(RangeT&& range, std::bool_constant<IsAnyView>)
-        : poly(adaptor_for<std::views::all_t<RangeT>>{.view = std::views::all(std::forward<RangeT>(range))}) {}
-
-    template <class RangeT>
-    static consteval bool is_noexcept() {
-        return detail::is_any_view<std::remove_cvref_t<RangeT>>::value and requires {
-            { polymorphic_type(std::declval<RangeT>().poly) } noexcept;
-        };
+    static constexpr polymorphic_type make_default() {
+        return polymorphic_type(
+            std::in_place_type<adaptor_for<detail::default_view<ElementT, RefT, RValueRefT, DiffT>>>);
     }
 
-    template <class RangeT>
-        requires std::constructible_from<polymorphic_type, decltype(std::declval<RangeT>().poly)>
-    constexpr any_view(RangeT&& range, std::true_type) noexcept(is_noexcept<RangeT>())
-        : poly(std::forward<RangeT>(range).poly) {}
+    polymorphic_type poly{make_default()};
+
+    constexpr const polymorphic_type& polymorphic() const& noexcept { return poly; }
+
+    constexpr polymorphic_type polymorphic() && noexcept { return std::exchange(poly, make_default()); }
+
+    // type erase
+    template <class RangeT, class InPlaceTypeT>
+    constexpr any_view(RangeT&& range, InPlaceTypeT)
+        : poly(adaptor_for<std::views::all_t<RangeT>>{.view = std::views::all(std::forward<RangeT>(range))}) {}
+
+    // upcast
+    template <class RangeT, class OtherElementT, any_view_options OtherOptsV>
+        requires std::constructible_from<polymorphic_type, decltype(std::declval<RangeT>().polymorphic())>
+    constexpr any_view(
+        RangeT&& range,
+        std::in_place_type_t<any_view<OtherElementT,
+                                      OtherOptsV,
+                                      RefT,
+                                      RValueRefT,
+                                      DiffT>>) noexcept(noexcept(polymorphic_type(std::forward<RangeT>(range)
+                                                                                      .polymorphic())))
+        : poly(std::forward<RangeT>(range).polymorphic()) {}
+
+    template <detail::capability CapabilityT, detail::storage StorageT>
+    using vtable_for = detail::vtable<typename CapabilityT::template capabilities_for<OptsV>, StorageT>;
+
+    template <detail::polymorphic PolyT, class GetStorageT>
+        requires std::is_invocable_r_v<detail::view_storage, GetStorageT>
+    [[nodiscard]] constexpr PolyT make_const(GetStorageT get_storage) const {
+        using reference           = detail::const_reference_t<value_type, RefT>;
+        using rvalue_reference    = detail::const_reference_t<value_type, RValueRefT>;
+        using const_copyable_type = detail::const_copyable_vtable_t<reference, rvalue_reference, DiffT>;
+        using const_sized_type    = detail::const_sized_vtable_t<reference, rvalue_reference, DiffT>;
+
+        const auto const_copyable_vtable_ptr =
+            static_cast<const vtable_for<const_copyable_type, detail::view_storage>*>(
+                dispatch<const_copyable_type>(poly));
+        const auto const_sized_vtable_ptr =
+            static_cast<const vtable_for<const_sized_type, detail::view_storage>*>(dispatch<const_sized_type>(poly));
+
+        return PolyT(get_storage, const_copyable_vtable_ptr, const_sized_vtable_ptr);
+    }
+
+    template <detail::polymorphic PolyT>
+    [[nodiscard]] constexpr explicit operator PolyT() const& {
+        return make_const<PolyT>([this] { return dispatch<detail::copy_t<detail::view_storage>>(poly); });
+    }
+
+    template <detail::polymorphic PolyT>
+    [[nodiscard]] constexpr explicit operator PolyT() && noexcept {
+        return make_const<PolyT>([this] {
+            return poly.entry(detail::move_t<detail::view_storage>{})(std::move(*this).polymorphic().get());
+        });
+    }
+
+    // const_cast
+    template <class RangeT,
+              class OtherElementT,
+              any_view_options OtherOptsV,
+              class OtherValueT = std::remove_cv_t<OtherElementT>,
+              detail::const_reference_with<OtherValueT> OtherRefT,
+              detail::const_reference_with<OtherValueT> OtherRValueRefT>
+        requires std::same_as<detail::const_reference_t<OtherValueT, OtherRefT>, RefT> and
+                 std::same_as<detail::const_reference_t<OtherValueT, OtherRValueRefT>, RValueRefT>
+    constexpr any_view(
+        RangeT&& range,
+        std::in_place_type_t<any_view<OtherElementT,
+                                      OtherOptsV,
+                                      OtherRefT,
+                                      OtherRValueRefT,
+                                      DiffT>>) noexcept(noexcept(polymorphic_type(std::forward<RangeT>(range))))
+        : poly(std::forward<RangeT>(range)) {}
 
   public:
     // [range.any.ctor]
     template <class RangeT>
         requires detail::different_from<RangeT, any_view> and
                  ext_any_compatible_range<RangeT, RefT, RValueRefT, DiffT, OptsV>
-    constexpr any_view(RangeT&& range) noexcept(is_noexcept<RangeT>())
-        : any_view(std::forward<RangeT>(range), detail::is_any_view<std::remove_cvref_t<RangeT>>{}) {
+    constexpr any_view(RangeT&& range) noexcept(noexcept(any_view(std::forward<RangeT>(range),
+                                                                  std::in_place_type<std::remove_cvref_t<RangeT>>)))
+        : any_view(std::forward<RangeT>(range), std::in_place_type<std::remove_cvref_t<RangeT>>) {
         static_assert(std::ranges::viewable_range<RangeT>, "range must be viewable");
         if constexpr (copyable) {
             static_assert(std::copyable<std::views::all_t<RangeT>>,
@@ -115,12 +175,11 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
 
     // [range.any.access]
     [[nodiscard]] constexpr iterator begin() {
-        using capability_type     = detail::iterator_capabilities<RefT, RValueRefT, DiffT, OptsV>;
-        using derived_vtable_type = detail::vtable<capability_type, detail::iterator_storage>;
+        using capability_type = detail::iterator_vtable_t<RefT, RValueRefT, DiffT>;
 
-        const auto get_storage = [this] { return dispatch<detail::begin_t<RefT, RValueRefT, DiffT>>(poly); };
-        const auto vtable_ptr  = static_cast<const derived_vtable_type*>(
-            dispatch<detail::iterator_vtable_t<RefT, RValueRefT, DiffT>>(poly));
+        const auto get_storage = [this] { return dispatch<detail::begin_t>(poly); };
+        const auto vtable_ptr =
+            static_cast<const vtable_for<capability_type, detail::iterator_storage>*>(dispatch<capability_type>(poly));
 
         if constexpr (contiguous_and_sized) {
             const auto to_address = &detail::vtable<detail::cache_t<RefT>, detail::iterator_storage>::entry;
@@ -150,9 +209,6 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
 
     constexpr friend void swap(any_view& lhs, any_view& rhs) noexcept { return lhs.swap(rhs); }
 };
-
-template <class ElementT, any_view_options OptsV, class RefT, class RValueRefT, class DiffT>
-struct detail::is_any_view<any_view<ElementT, OptsV, RefT, RValueRefT, DiffT>> : std::true_type {};
 
 } // namespace beman::any_view
 

--- a/include/beman/any_view/detail/capabilities.hpp
+++ b/include/beman/any_view/detail/capabilities.hpp
@@ -44,9 +44,19 @@ struct impl<binding<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...) noexcept> {
 
 // bindings for unary capabilities
 template <unary UnaryT, adaptor AdaptorT, storage StorageT, class RetT, class SelfT, class... ArgsT>
-struct impl<binding<UnaryT, AdaptorT>, StorageT, RetT(SelfT&, ArgsT...)> {
-    [[nodiscard]] static constexpr RetT fn(SelfT& self, ArgsT... args) {
-        return dispatch<UnaryT, AdaptorT>(self.template unchecked_get<AdaptorT>(), std::forward<ArgsT>(args)...);
+struct impl<binding<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...)> {
+    [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) {
+        return dispatch<UnaryT, AdaptorT>(std::forward<SelfT>(self).template unchecked_get<AdaptorT>(),
+                                          std::forward<ArgsT>(args)...);
+    }
+};
+
+// bindings for noexcept unary capabilities
+template <unary UnaryT, adaptor AdaptorT, storage StorageT, class RetT, class SelfT, class... ArgsT>
+struct impl<binding<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...) noexcept> {
+    [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) noexcept {
+        return dispatch<UnaryT, AdaptorT>(std::forward<SelfT>(self).template unchecked_get<AdaptorT>(),
+                                          std::forward<ArgsT>(args)...);
     }
 };
 
@@ -94,9 +104,17 @@ struct impl<NullaryT, PolyT, RetT(ArgsT...) noexcept> {
 
 // dispatches to bindings for unary capabilities
 template <unary UnaryT, polymorphic PolyT, class RetT, class SelfT, class... ArgsT>
-struct impl<UnaryT, PolyT, RetT(SelfT&, ArgsT...)> {
-    [[nodiscard]] static constexpr RetT fn(SelfT& self, ArgsT... args) {
-        return self.entry(UnaryT{})(self.get(), std::forward<ArgsT>(args)...);
+struct impl<UnaryT, PolyT, RetT(SelfT, ArgsT...)> {
+    [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) {
+        return self.entry(UnaryT{})(std::forward<SelfT>(self).get(), std::forward<ArgsT>(args)...);
+    }
+};
+
+// dispatches to bindings for noexcept unary capabilities
+template <unary UnaryT, polymorphic PolyT, class RetT, class SelfT, class... ArgsT>
+struct impl<UnaryT, PolyT, RetT(SelfT, ArgsT...) noexcept> {
+    [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) noexcept {
+        return self.entry(UnaryT{})(std::forward<SelfT>(self).get(), std::forward<ArgsT>(args)...);
     }
 };
 

--- a/include/beman/any_view/detail/polymorphic.hpp
+++ b/include/beman/any_view/detail/polymorphic.hpp
@@ -93,8 +93,10 @@ class basic_polymorphic {
         return *this;
     }
 
-    constexpr StorageT&       get() noexcept { return storage; }
-    constexpr const StorageT& get() const noexcept { return storage; }
+    constexpr StorageT&       get() & noexcept { return storage; }
+    constexpr const StorageT& get() const& noexcept { return storage; }
+    constexpr StorageT&&      get() && noexcept { return std::move(storage); }
+    // constexpr const StorageT&& get() const&& noexcept { return std::move(storage); }
 
     constexpr vtable_ptrs_type entries() const noexcept { return vtable_ptrs; }
 

--- a/include/beman/any_view/detail/polymorphic_view.hpp
+++ b/include/beman/any_view/detail/polymorphic_view.hpp
@@ -10,21 +10,22 @@ namespace beman::any_view::detail {
 
 template <class RefT, class RValueRefT, class DiffT>
 struct iterator_vtable_t : nullary_capability {
-    using vtable_type = vtable<input_capabilities<RefT, RValueRefT>, iterator_storage>;
+    template <any_view_options OptsV>
+    using capabilities_for = iterator_capabilities<RefT, RValueRefT, DiffT, OptsV>;
+
+    using vtable_type = vtable<capabilities_for<any_view_options::input>, iterator_storage>;
 
     template <not_adaptor>
     static const vtable_type* fn() noexcept;
 
     template <adaptor ViewAdaptorT>
     [[nodiscard]] static constexpr const vtable_type* fn() noexcept {
-        constexpr auto options = ViewAdaptorT::options;
-        using capability_type  = iterator_capabilities<RefT, RValueRefT, DiffT, options>;
-        using adaptor_type     = typename ViewAdaptorT::adaptor_type;
+        using capability_type = capabilities_for<ViewAdaptorT::options>;
+        using adaptor_type    = typename ViewAdaptorT::adaptor_type;
         return std::addressof(vtable_for<capability_type, iterator_storage, adaptor_type>);
     }
 };
 
-template <class RefT, class RValueRefT, class DiffT>
 struct begin_t : unary_capability {
     template <not_adaptor T>
     static iterator_storage fn(T& self);
@@ -55,28 +56,92 @@ struct reserve_hint_t : unary_capability {
 // inplace storage sufficient for a std::vector<T>
 using view_storage = small_storage<3 * sizeof(void*)>;
 
-template <class RefT, class RValueRefT, class DiffT>
+template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
+consteval auto get_copyable_capabilities();
+
+template <class ConstRefT, class ConstRValueRefT, class DiffT>
+struct const_copyable_vtable_t : nullary_capability {
+    template <any_view_options OptsV>
+    using capabilities_for = decltype(get_copyable_capabilities<void, ConstRefT, ConstRValueRefT, DiffT, OptsV>());
+
+    using vtable_type = vtable<capabilities_for<any_view_options{}>, view_storage>;
+
+    template <not_adaptor>
+    static const vtable_type* fn() noexcept;
+
+    template <adaptor ViewAdaptorT>
+    [[nodiscard]] static constexpr const vtable_type* fn() noexcept {
+        using capability_type = capabilities_for<ViewAdaptorT::options>;
+        return std::addressof(vtable_for<capability_type, view_storage, ViewAdaptorT>);
+    }
+};
+
+template <class DiffT, any_view_options OptsV>
+consteval auto get_sized_capabilities();
+
+template <class ConstRefT, class ConstRValueRefT, class DiffT>
+struct const_sized_vtable_t : nullary_capability {
+    template <any_view_options OptsV>
+    using capabilities_for = decltype(get_sized_capabilities<DiffT, OptsV>());
+
+    using vtable_type = vtable<capabilities_for<any_view_options{}>, view_storage>;
+
+    template <not_adaptor>
+    static const vtable_type* fn() noexcept;
+
+    template <adaptor ViewAdaptorT>
+    [[nodiscard]] static constexpr const vtable_type* fn() noexcept {
+        using capability_type = capabilities_for<ViewAdaptorT::options>;
+        return std::addressof(vtable_for<capability_type, view_storage, ViewAdaptorT>);
+    }
+};
+
+template <class ValueT, class RefT>
+using const_reference_t = std::common_reference_t<const ValueT&&, RefT>;
+
+template <class RefT, class ValueT>
+concept const_reference_with =
+    std::common_reference_with<RefT, const ValueT&&> and not std::same_as<RefT, const_reference_t<ValueT, RefT>>;
+
+template <class ValueT, class RefT, class RValueRefT, class DiffT>
+struct const_capabilities {
+    using type = inherit<>;
+};
+
+template <class ValueT, const_reference_with<ValueT> RefT, const_reference_with<ValueT> RValueRefT, class DiffT>
+struct const_capabilities<ValueT, RefT, RValueRefT, DiffT> {
+    using reference        = const_reference_t<ValueT, RefT>;
+    using rvalue_reference = const_reference_t<ValueT, RValueRefT>;
+    using type             = inherit<const_copyable_vtable_t<reference, rvalue_reference, DiffT>,
+                                     const_sized_vtable_t<reference, rvalue_reference, DiffT>>;
+};
+
+template <class ValueT, class RefT, class RValueRefT, class DiffT>
+using const_capabilities_t = typename const_capabilities<ValueT, RefT, RValueRefT, DiffT>::type;
+
+template <class ValueT, class RefT, class RValueRefT, class DiffT>
 using uncopyable_capabilities = inherit<move_t<view_storage>,
                                         destroy_t<view_storage>,
                                         iterator_vtable_t<RefT, RValueRefT, DiffT>,
-                                        begin_t<RefT, RValueRefT, DiffT>>;
+                                        begin_t,
+                                        const_capabilities_t<ValueT, RefT, RValueRefT, DiffT>>;
 
-template <class RefT, class RValueRefT, class DiffT>
-using copyable_capabilities = inherit<uncopyable_capabilities<RefT, RValueRefT, DiffT>, copy_t<view_storage>>;
+template <class ValueT, class RefT, class RValueRefT, class DiffT>
+using copyable_capabilities = inherit<uncopyable_capabilities<ValueT, RefT, RValueRefT, DiffT>, copy_t<view_storage>>;
 
 using unsized_capabilities = inherit<>;
 
 template <class DiffT>
 using sized_capabilities = inherit<unsized_capabilities, reserve_hint_t<DiffT>>;
 
-template <class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
+template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
 consteval auto get_copyable_capabilities() {
     using enum any_view_options;
 
     if constexpr (flag_is_set<OptsV, copyable>) {
-        return copyable_capabilities<RefT, RValueRefT, DiffT>{};
+        return copyable_capabilities<ValueT, RefT, RValueRefT, DiffT>{};
     } else {
-        return uncopyable_capabilities<RefT, RValueRefT, DiffT>{};
+        return uncopyable_capabilities<ValueT, RefT, RValueRefT, DiffT>{};
     }
 }
 
@@ -91,10 +156,11 @@ consteval auto get_sized_capabilities() {
     }
 }
 
-template <class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
-using polymorphic_view = basic_polymorphic<view_storage,
-                                           decltype(get_copyable_capabilities<RefT, RValueRefT, DiffT, OptsV>()),
-                                           decltype(get_sized_capabilities<DiffT, OptsV>())>;
+template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
+using polymorphic_view =
+    basic_polymorphic<view_storage,
+                      decltype(get_copyable_capabilities<ValueT, RefT, RValueRefT, DiffT, OptsV>()),
+                      decltype(get_sized_capabilities<DiffT, OptsV>())>;
 
 } // namespace beman::any_view::detail
 

--- a/include/beman/any_view/detail/small_storage.hpp
+++ b/include/beman/any_view/detail/small_storage.hpp
@@ -71,7 +71,7 @@ class small_storage {
     }
 
     template <adaptor AdaptorT>
-    [[nodiscard]] constexpr AdaptorT& unchecked_get() {
+    [[nodiscard]] constexpr AdaptorT& unchecked_get() & noexcept {
         return visit<AdaptorT>(
             *this,
             [](inplace_type& inplace) -> AdaptorT& { return reinterpret_cast<AdaptorT&>(inplace); },
@@ -79,12 +79,23 @@ class small_storage {
     }
 
     template <adaptor AdaptorT>
-    [[nodiscard]] constexpr const AdaptorT& unchecked_get() const {
+    [[nodiscard]] constexpr const AdaptorT& unchecked_get() const& noexcept {
         return visit<AdaptorT>(
             *this,
             [](const inplace_type& inplace) -> const AdaptorT& { return reinterpret_cast<const AdaptorT&>(inplace); },
             [](const pointer_type& pointer) -> const AdaptorT& { return static_cast<const AdaptorT&>(*pointer); });
     }
+
+    template <adaptor AdaptorT>
+    [[nodiscard]] constexpr AdaptorT&& unchecked_get() && noexcept {
+        return visit<AdaptorT>(
+            *this,
+            [](inplace_type& inplace) -> AdaptorT&& { return reinterpret_cast<AdaptorT&&>(inplace); },
+            [](pointer_type& pointer) -> AdaptorT&& { return static_cast<AdaptorT&&>(*pointer); });
+    }
+
+    // template <adaptor AdaptorT>
+    // [[nodiscard]] constexpr const AdaptorT&& unchecked_get() const&& noexcept;
 
   private:
     template <adaptor AdaptorT, class SelfT, class InplaceVisitorT, class PointerVisitorT>

--- a/tests/beman/any_view/constexpr.test.cpp
+++ b/tests/beman/any_view/constexpr.test.cpp
@@ -124,7 +124,7 @@ TEST(ConstexprTest, add_const) {
         return view;
     };
 
-    static_assert(not std::is_nothrow_constructible_v<any_view<const int>, any_view<int>>);
+    static_assert(std::is_nothrow_constructible_v<any_view<const int>, any_view<int>>);
 #ifndef _MSC_VER
     // error C2131: expression did not evaluate to a constant
     static_assert(make_add_const().front() == 7);


### PR DESCRIPTION
This optimization ended up being very interesting work, and I discovered an invariant that `any_view`'s design guarantees correct by construction:

> Given an object `v` of type `any_view<Elem, Opts, Ref, RValue, Diff>` for which `views::as_const(v)` is well-formed, `views::as_const(t)` must be well-formed for every target view `t` of `v`.
> 
> Given `Value` as `remove_cv_t<Elem>`, every target view `t` of `v` must also satisfy the requirement `convertible_to<any_view<Elem, Opts, common_reference_t<const Value&&, Ref>, common_reference_t<const Value&&, RValue>, Diff>>`.

What this means for the optimization is that if `common_reference_with<const Value&&, Ref>` and `common_reference_with<const Value&&, RValue>` both hold for a given specialization of `any_view`, then that specialization can define vtable entries to produce vtable pointers of the corresponding specialization of `any_view` during a converting construction, and allow operations on `any_view<const T>` to dispatch directly on the original target view, instead of forcing the user to type-erase `v` and route every operation on the view and its iterators through two virtual dispatches.

```cpp
any_view<std::string> get_view();
void process_view(any_view<const std::string> v);

int main() {
  // before, this would type-erase any_view<string>
  // now it directly wraps the target view instead
  process_view(get_view());
}
```

Additionally, for specializations of `any_view` where `common_reference_t<const Value&&, Ref>` and `common_reference_t<const Value&&, RValue>` either result in substitution failure, or are well-formed but the same types as `Ref` and `RValue` respectively, we do not define these vtable entries.