### PR TITLE
Strong table types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ target_sources(
             include
         FILES
             include/beman/any_view/detail/adaptors.hpp
-            include/beman/any_view/detail/capabilities.hpp
             include/beman/any_view/detail/compressed_ptr.hpp
             include/beman/any_view/detail/concepts.hpp
             include/beman/any_view/detail/default_iterator.hpp
@@ -60,6 +59,7 @@ target_sources(
             include/beman/any_view/detail/polymorphic_iterator.hpp
             include/beman/any_view/detail/polymorphic_view.hpp
             include/beman/any_view/detail/polymorphic.hpp
+            include/beman/any_view/detail/protocols.hpp
             include/beman/any_view/detail/reference_converts_from_temporary.hpp
             include/beman/any_view/detail/small_storage.hpp
             include/beman/any_view/detail/unreachable.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ target_sources(
             include/beman/any_view/detail/reference_converts_from_temporary.hpp
             include/beman/any_view/detail/small_storage.hpp
             include/beman/any_view/detail/unreachable.hpp
-            include/beman/any_view/detail/vtable.hpp
+            include/beman/any_view/detail/witness.hpp
             include/beman/any_view/any_view_options.hpp
             include/beman/any_view/any_view.hpp
             include/beman/any_view/concepts.hpp

--- a/include/beman/any_view/any_view.hpp
+++ b/include/beman/any_view/any_view.hpp
@@ -90,23 +90,23 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
         : poly(std::forward<RangeT>(range).polymorphic()) {}
 
     template <detail::capability CapabilityT, detail::storage StorageT>
-    using vtable_for = detail::vtable<typename CapabilityT::template capabilities_for<OptsV>, StorageT>;
+    using witness_for = detail::witness<typename CapabilityT::template capabilities_for<OptsV>, StorageT>;
 
     template <detail::polymorphic PolyT, class GetStorageT>
         requires std::is_invocable_r_v<detail::view_storage, GetStorageT>
     [[nodiscard]] constexpr PolyT make_const(GetStorageT get_storage) const {
         using reference           = detail::const_reference_t<value_type, RefT>;
         using rvalue_reference    = detail::const_reference_t<value_type, RValueRefT>;
-        using const_copyable_type = detail::const_copyable_vtable_t<reference, rvalue_reference, DiffT>;
-        using const_sized_type    = detail::const_sized_vtable_t<reference, rvalue_reference, DiffT>;
+        using const_copyable_type = detail::const_copyable_witness_t<reference, rvalue_reference, DiffT>;
+        using const_sized_type    = detail::const_sized_witness_t<reference, rvalue_reference, DiffT>;
 
-        const auto const_copyable_vtable_ptr =
-            static_cast<const vtable_for<const_copyable_type, detail::view_storage>*>(
+        const auto const_copyable_witness_ptr =
+            static_cast<const witness_for<const_copyable_type, detail::view_storage>*>(
                 dispatch<const_copyable_type>(poly));
-        const auto const_sized_vtable_ptr =
-            static_cast<const vtable_for<const_sized_type, detail::view_storage>*>(dispatch<const_sized_type>(poly));
+        const auto const_sized_witness_ptr =
+            static_cast<const witness_for<const_sized_type, detail::view_storage>*>(dispatch<const_sized_type>(poly));
 
-        return PolyT(get_storage, const_copyable_vtable_ptr, const_sized_vtable_ptr);
+        return PolyT(get_storage, const_copyable_witness_ptr, const_sized_witness_ptr);
     }
 
     template <detail::polymorphic PolyT>
@@ -122,14 +122,8 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
     }
 
     // const_cast
-    template <class RangeT,
-              class OtherElementT,
-              any_view_options OtherOptsV,
-              class OtherValueT = std::remove_cv_t<OtherElementT>,
-              detail::const_reference_with<OtherValueT> OtherRefT,
-              detail::const_reference_with<OtherValueT> OtherRValueRefT>
-        requires std::same_as<detail::const_reference_t<OtherValueT, OtherRefT>, RefT> and
-                 std::same_as<detail::const_reference_t<OtherValueT, OtherRValueRefT>, RValueRefT>
+    template <class RangeT, class OtherElementT, any_view_options OtherOptsV, class OtherRefT, class OtherRValueRefT>
+        requires detail::const_capable<std::remove_cv_t<OtherElementT>, OtherRefT, OtherRValueRefT>
     constexpr any_view(
         RangeT&& range,
         std::in_place_type_t<any_view<OtherElementT,
@@ -175,18 +169,19 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
 
     // [range.any.access]
     [[nodiscard]] constexpr iterator begin() {
-        using capability_type = detail::iterator_vtable_t<RefT, RValueRefT, DiffT>;
+        using capability_type = detail::iterator_witness_t<RefT, RValueRefT, DiffT>;
 
         const auto get_storage = [this] { return dispatch<detail::begin_t>(poly); };
-        const auto vtable_ptr =
-            static_cast<const vtable_for<capability_type, detail::iterator_storage>*>(dispatch<capability_type>(poly));
+        const auto witness_ptr = static_cast<const witness_for<capability_type, detail::iterator_storage>*>(
+            dispatch<capability_type>(poly));
 
         if constexpr (contiguous_and_sized) {
-            const auto to_address = &detail::vtable<detail::cache_t<RefT>, detail::iterator_storage>::entry;
-            return iterator{(vtable_ptr->*to_address)(get_storage()), static_cast<DiffT>(size())};
+            const auto to_address = &detail::witness<detail::cache_t<RefT>, detail::iterator_storage>::entry;
+            return iterator{(witness_ptr->*to_address)(get_storage()), static_cast<DiffT>(size())};
         } else {
-            return iterator{
-                [=] { return detail::polymorphic_iterator<RefT, RValueRefT, DiffT, OptsV>{get_storage, vtable_ptr}; }};
+            return iterator{[=] {
+                return detail::polymorphic_iterator<RefT, RValueRefT, DiffT, OptsV>{get_storage, witness_ptr};
+            }};
         }
     }
 

--- a/include/beman/any_view/any_view.hpp
+++ b/include/beman/any_view/any_view.hpp
@@ -123,7 +123,7 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
 
     // const_cast
     template <class RangeT, class OtherElementT, any_view_options OtherOptsV, class OtherRefT, class OtherRValueRefT>
-        requires detail::const_capable<std::remove_cv_t<OtherElementT>, OtherRefT, OtherRValueRefT>
+        requires detail::const_convertible<std::remove_cv_t<OtherElementT>, OtherRefT, OtherRValueRefT>
     constexpr any_view(
         RangeT&& range,
         std::in_place_type_t<any_view<OtherElementT,

--- a/include/beman/any_view/any_view.hpp
+++ b/include/beman/any_view/any_view.hpp
@@ -54,8 +54,8 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
     using sentinel         = std::default_sentinel_t;
     using size_type        = std::make_unsigned_t<DiffT>;
 
-    template <detail::capability CapabilityT>
-    static constexpr auto dispatch = detail::dispatch<CapabilityT, polymorphic_type>;
+    template <detail::protocol ProtocolT>
+    static constexpr auto dispatch = detail::dispatch<ProtocolT, polymorphic_type>;
 
     template <std::ranges::view ViewT>
     using adaptor_for = detail::view_adaptor<ViewT, OptsV>;
@@ -89,8 +89,8 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
                                                                                       .polymorphic())))
         : poly(std::forward<RangeT>(range).polymorphic()) {}
 
-    template <detail::capability CapabilityT, detail::storage StorageT>
-    using witness_for = detail::witness<typename CapabilityT::template capabilities_for<OptsV>, StorageT>;
+    template <detail::protocol ProtocolT, detail::storage StorageT>
+    using witness_for = detail::witness<typename ProtocolT::template protocol_for<OptsV>, StorageT>;
 
     template <detail::polymorphic PolyT, class GetStorageT>
         requires std::is_invocable_r_v<detail::view_storage, GetStorageT>
@@ -169,11 +169,11 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
 
     // [range.any.access]
     [[nodiscard]] constexpr iterator begin() {
-        using capability_type = detail::iterator_witness_t<RefT, RValueRefT, DiffT>;
+        using protocol_type = detail::iterator_witness_t<RefT, RValueRefT, DiffT>;
 
         const auto get_storage = [this] { return dispatch<detail::begin_t>(poly); };
-        const auto witness_ptr = static_cast<const witness_for<capability_type, detail::iterator_storage>*>(
-            dispatch<capability_type>(poly));
+        const auto witness_ptr =
+            static_cast<const witness_for<protocol_type, detail::iterator_storage>*>(dispatch<protocol_type>(poly));
 
         if constexpr (contiguous_and_sized) {
             const auto to_address = &detail::witness<detail::cache_t<RefT>, detail::iterator_storage>::entry;

--- a/include/beman/any_view/detail/capabilities.hpp
+++ b/include/beman/any_view/detail/capabilities.hpp
@@ -28,7 +28,7 @@ concept symmetric_binary = capability<T> and std::derived_from<T, symmetric_bina
 
 // bindings for nullary capabilities
 template <nullary NullaryT, adaptor AdaptorT, storage StorageT, class RetT, class... ArgsT>
-struct impl<binding<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...)> {
+struct bridge<thunk<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...)> {
     [[nodiscard]] static constexpr RetT fn(ArgsT... args) {
         return dispatch<NullaryT, AdaptorT>(std::forward<ArgsT>(args)...);
     }
@@ -36,7 +36,7 @@ struct impl<binding<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...)> {
 
 // bindings for noexcept nullary capabilities
 template <nullary NullaryT, adaptor AdaptorT, storage StorageT, class RetT, class... ArgsT>
-struct impl<binding<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...) noexcept> {
+struct bridge<thunk<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...) noexcept> {
     [[nodiscard]] static constexpr RetT fn(ArgsT... args) noexcept {
         return dispatch<NullaryT, AdaptorT>(std::forward<ArgsT>(args)...);
     }
@@ -44,7 +44,7 @@ struct impl<binding<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...) noexcept> {
 
 // bindings for unary capabilities
 template <unary UnaryT, adaptor AdaptorT, storage StorageT, class RetT, class SelfT, class... ArgsT>
-struct impl<binding<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...)> {
+struct bridge<thunk<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...)> {
     [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) {
         return dispatch<UnaryT, AdaptorT>(std::forward<SelfT>(self).template unchecked_get<AdaptorT>(),
                                           std::forward<ArgsT>(args)...);
@@ -53,7 +53,7 @@ struct impl<binding<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...)> {
 
 // bindings for noexcept unary capabilities
 template <unary UnaryT, adaptor AdaptorT, storage StorageT, class RetT, class SelfT, class... ArgsT>
-struct impl<binding<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...) noexcept> {
+struct bridge<thunk<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...) noexcept> {
     [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) noexcept {
         return dispatch<UnaryT, AdaptorT>(std::forward<SelfT>(self).template unchecked_get<AdaptorT>(),
                                           std::forward<ArgsT>(args)...);
@@ -69,9 +69,9 @@ struct type_t : nullary_capability {
 
 // bindings for symmetric binary capabilities
 template <symmetric_binary SymmetricBinaryT, adaptor AdaptorT, storage StorageT, class RetT>
-struct impl<binding<SymmetricBinaryT, AdaptorT>,
-            StorageT,
-            RetT(const StorageT&, const StorageT&, const std::type_info&)> {
+struct bridge<thunk<SymmetricBinaryT, AdaptorT>,
+              StorageT,
+              RetT(const StorageT&, const StorageT&, const std::type_info&)> {
     [[nodiscard]] static constexpr RetT
     fn(const StorageT& self, const StorageT& other, const std::type_info& other_type) {
         const auto& self_type = typeid(AdaptorT);
@@ -88,7 +88,7 @@ struct impl<binding<SymmetricBinaryT, AdaptorT>,
 
 // dispatches to bindings for nullary capabilities
 template <nullary NullaryT, polymorphic PolyT, class RetT, class... ArgsT>
-struct impl<NullaryT, PolyT, RetT(ArgsT...)> {
+struct bridge<NullaryT, PolyT, RetT(ArgsT...)> {
     [[nodiscard]] static constexpr RetT fn(const PolyT& self, ArgsT... args) {
         return self.entry(NullaryT{})(std::forward<ArgsT>(args)...);
     }
@@ -96,7 +96,7 @@ struct impl<NullaryT, PolyT, RetT(ArgsT...)> {
 
 // dispatches to bindings for noexcept nullary capabilities
 template <nullary NullaryT, polymorphic PolyT, class RetT, class... ArgsT>
-struct impl<NullaryT, PolyT, RetT(ArgsT...) noexcept> {
+struct bridge<NullaryT, PolyT, RetT(ArgsT...) noexcept> {
     [[nodiscard]] static constexpr RetT fn(const PolyT& self, ArgsT... args) noexcept {
         return self.entry(NullaryT{})(std::forward<ArgsT>(args)...);
     }
@@ -104,7 +104,7 @@ struct impl<NullaryT, PolyT, RetT(ArgsT...) noexcept> {
 
 // dispatches to bindings for unary capabilities
 template <unary UnaryT, polymorphic PolyT, class RetT, class SelfT, class... ArgsT>
-struct impl<UnaryT, PolyT, RetT(SelfT, ArgsT...)> {
+struct bridge<UnaryT, PolyT, RetT(SelfT, ArgsT...)> {
     [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) {
         return self.entry(UnaryT{})(std::forward<SelfT>(self).get(), std::forward<ArgsT>(args)...);
     }
@@ -112,7 +112,7 @@ struct impl<UnaryT, PolyT, RetT(SelfT, ArgsT...)> {
 
 // dispatches to bindings for noexcept unary capabilities
 template <unary UnaryT, polymorphic PolyT, class RetT, class SelfT, class... ArgsT>
-struct impl<UnaryT, PolyT, RetT(SelfT, ArgsT...) noexcept> {
+struct bridge<UnaryT, PolyT, RetT(SelfT, ArgsT...) noexcept> {
     [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) noexcept {
         return self.entry(UnaryT{})(std::forward<SelfT>(self).get(), std::forward<ArgsT>(args)...);
     }
@@ -121,7 +121,7 @@ struct impl<UnaryT, PolyT, RetT(SelfT, ArgsT...) noexcept> {
 // dispatches to bindings for symmetric binary capabilities
 // requires type_t to be implemented
 template <symmetric_binary SymmetricBinaryT, polymorphic PolyT, class RetT>
-struct impl<SymmetricBinaryT, PolyT, RetT(const PolyT&, const PolyT&)> {
+struct bridge<SymmetricBinaryT, PolyT, RetT(const PolyT&, const PolyT&)> {
     [[nodiscard]] static constexpr RetT fn(const PolyT& self, const PolyT& other) {
         return self.entry(SymmetricBinaryT{})(self.get(), other.get(), other.entry(type_t{})());
     }

--- a/include/beman/any_view/detail/iterator.hpp
+++ b/include/beman/any_view/detail/iterator.hpp
@@ -66,8 +66,8 @@ class iterator : public iterator_category_type<iterator_concept_t<OptsV>, std::i
 
     static constexpr bool has_index = std::is_same_v<cache_or_index_type, DiffT>;
 
-    template <capability CapabilityT>
-    static constexpr auto dispatch = detail::dispatch<CapabilityT, polymorphic_type>;
+    template <protocol ProtocolT>
+    static constexpr auto dispatch = detail::dispatch<ProtocolT, polymorphic_type>;
 
     polymorphic_type poly{std::in_place_type<iterator_adaptor_for<default_view<ElementT, RefT, RValueRefT, DiffT>>>};
     BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS cache_or_index_type cache_or_index{make_cache_or_index()};

--- a/include/beman/any_view/detail/polymorphic.hpp
+++ b/include/beman/any_view/detail/polymorphic.hpp
@@ -3,16 +3,16 @@
 #ifndef BEMAN_ANY_VIEW_DETAIL_POLYMORPHIC_HPP
 #define BEMAN_ANY_VIEW_DETAIL_POLYMORPHIC_HPP
 
-#include <beman/any_view/detail/capabilities.hpp>
 #include <beman/any_view/detail/compressed_ptr.hpp>
+#include <beman/any_view/detail/protocols.hpp>
 
 #include <memory>
 
 namespace beman::any_view::detail {
 
-template <storage StorageT, capability... CapabilityTs>
+template <storage StorageT, protocol... ProtocolTs>
 class basic_polymorphic {
-    using witness_ptrs_type = compressed_ptr<const witness<CapabilityTs, StorageT>...>;
+    using witness_ptrs_type = compressed_ptr<const witness<ProtocolTs, StorageT>...>;
 
     StorageT          storage;
     witness_ptrs_type witness_ptrs;
@@ -27,25 +27,25 @@ class basic_polymorphic {
     template <adaptor AdaptorT>
     constexpr basic_polymorphic(AdaptorT&& adaptor)
         : storage(std::forward<AdaptorT>(adaptor)),
-          witness_ptrs(std::addressof(witness_for<CapabilityTs, StorageT, AdaptorT>)...) {}
+          witness_ptrs(std::addressof(witness_for<ProtocolTs, StorageT, AdaptorT>)...) {}
 
     template <adaptor AdaptorT>
     constexpr basic_polymorphic(std::in_place_type_t<AdaptorT> tag)
-        : storage(tag), witness_ptrs(std::addressof(witness_for<CapabilityTs, StorageT, AdaptorT>)...) {}
+        : storage(tag), witness_ptrs(std::addressof(witness_for<ProtocolTs, StorageT, AdaptorT>)...) {}
 
     template <class GetStorageT>
         requires std::is_invocable_r_v<StorageT, GetStorageT>
-    constexpr basic_polymorphic(GetStorageT get_storage, const witness<CapabilityTs, StorageT>*... witness_ptrs)
+    constexpr basic_polymorphic(GetStorageT get_storage, const witness<ProtocolTs, StorageT>*... witness_ptrs)
         : storage(get_storage()), witness_ptrs(witness_ptrs...) {}
 
     // converting constructors
 
-    template <std::derived_from<CapabilityTs>... OtherCapabilityTs>
-    constexpr basic_polymorphic(const basic_polymorphic<StorageT, OtherCapabilityTs...>& other)
+    template <std::derived_from<ProtocolTs>... OtherProtocolTs>
+    constexpr basic_polymorphic(const basic_polymorphic<StorageT, OtherProtocolTs...>& other)
         : storage(other.entry(copy_t<StorageT>{})(other.get())), witness_ptrs(other.entries()) {}
 
-    template <std::derived_from<CapabilityTs>... OtherCapabilityTs>
-    constexpr basic_polymorphic(basic_polymorphic<StorageT, OtherCapabilityTs...>&& other) noexcept
+    template <std::derived_from<ProtocolTs>... OtherProtocolTs>
+    constexpr basic_polymorphic(basic_polymorphic<StorageT, OtherProtocolTs...>&& other) noexcept
         : storage(other.entry(move_t<StorageT>{})(std::move(other.get()))), witness_ptrs(other.entries()) {}
 
     constexpr ~basic_polymorphic() { entry(destroy_t<StorageT>{})(storage); }
@@ -79,15 +79,15 @@ class basic_polymorphic {
 
     // converting assignment
 
-    template <std::derived_from<CapabilityTs>... OtherCapabilityTs>
-    constexpr basic_polymorphic& operator=(const basic_polymorphic<StorageT, OtherCapabilityTs...>& other) {
+    template <std::derived_from<ProtocolTs>... OtherProtocolTs>
+    constexpr basic_polymorphic& operator=(const basic_polymorphic<StorageT, OtherProtocolTs...>& other) {
         std::destroy_at(this);
         std::construct_at(this, other);
         return *this;
     }
 
-    template <std::derived_from<CapabilityTs>... OtherCapabilityTs>
-    constexpr basic_polymorphic& operator=(basic_polymorphic<StorageT, OtherCapabilityTs...>&& other) noexcept {
+    template <std::derived_from<ProtocolTs>... OtherProtocolTs>
+    constexpr basic_polymorphic& operator=(basic_polymorphic<StorageT, OtherProtocolTs...>&& other) noexcept {
         std::destroy_at(this);
         std::construct_at(this, std::move(other));
         return *this;
@@ -100,15 +100,15 @@ class basic_polymorphic {
 
     constexpr witness_ptrs_type entries() const noexcept { return witness_ptrs; }
 
-    template <capability CapabilityT>
-        requires(... or std::derived_from<CapabilityTs, CapabilityT>)
-    constexpr const signature<CapabilityT, StorageT>* entry(CapabilityT) const noexcept {
-        return witness_ptrs->*&witness<CapabilityT, StorageT>::entry;
+    template <protocol ProtocolT>
+        requires(... or std::derived_from<ProtocolTs, ProtocolT>)
+    constexpr const signature<ProtocolT, StorageT>* entry(ProtocolT) const noexcept {
+        return witness_ptrs->*&witness<ProtocolT, StorageT>::entry;
     }
 };
 
-template <storage StorageT, capability... CapabilityTs>
-inline constexpr bool enable_polymorphic<basic_polymorphic<StorageT, CapabilityTs...>> = true;
+template <storage StorageT, protocol... ProtocolTs>
+inline constexpr bool enable_polymorphic<basic_polymorphic<StorageT, ProtocolTs...>> = true;
 
 } // namespace beman::any_view::detail
 

--- a/include/beman/any_view/detail/polymorphic.hpp
+++ b/include/beman/any_view/detail/polymorphic.hpp
@@ -12,41 +12,41 @@ namespace beman::any_view::detail {
 
 template <storage StorageT, capability... CapabilityTs>
 class basic_polymorphic {
-    using vtable_ptrs_type = compressed_ptr<const vtable<CapabilityTs, StorageT>...>;
+    using witness_ptrs_type = compressed_ptr<const witness<CapabilityTs, StorageT>...>;
 
-    StorageT         storage;
-    vtable_ptrs_type vtable_ptrs;
+    StorageT          storage;
+    witness_ptrs_type witness_ptrs;
 
   public:
     constexpr basic_polymorphic(const basic_polymorphic& other)
-        : storage(other.entry(copy_t<StorageT>{})(other.storage)), vtable_ptrs(other.vtable_ptrs) {}
+        : storage(other.entry(copy_t<StorageT>{})(other.storage)), witness_ptrs(other.witness_ptrs) {}
 
     constexpr basic_polymorphic(basic_polymorphic&& other) noexcept
-        : storage(other.entry(move_t<StorageT>{})(std::move(other.storage))), vtable_ptrs(other.vtable_ptrs) {}
+        : storage(other.entry(move_t<StorageT>{})(std::move(other.storage))), witness_ptrs(other.witness_ptrs) {}
 
     template <adaptor AdaptorT>
     constexpr basic_polymorphic(AdaptorT&& adaptor)
         : storage(std::forward<AdaptorT>(adaptor)),
-          vtable_ptrs(std::addressof(vtable_for<CapabilityTs, StorageT, AdaptorT>)...) {}
+          witness_ptrs(std::addressof(witness_for<CapabilityTs, StorageT, AdaptorT>)...) {}
 
     template <adaptor AdaptorT>
     constexpr basic_polymorphic(std::in_place_type_t<AdaptorT> tag)
-        : storage(tag), vtable_ptrs(std::addressof(vtable_for<CapabilityTs, StorageT, AdaptorT>)...) {}
+        : storage(tag), witness_ptrs(std::addressof(witness_for<CapabilityTs, StorageT, AdaptorT>)...) {}
 
     template <class GetStorageT>
         requires std::is_invocable_r_v<StorageT, GetStorageT>
-    constexpr basic_polymorphic(GetStorageT get_storage, const vtable<CapabilityTs, StorageT>*... vtable_ptrs)
-        : storage(get_storage()), vtable_ptrs(vtable_ptrs...) {}
+    constexpr basic_polymorphic(GetStorageT get_storage, const witness<CapabilityTs, StorageT>*... witness_ptrs)
+        : storage(get_storage()), witness_ptrs(witness_ptrs...) {}
 
     // converting constructors
 
     template <std::derived_from<CapabilityTs>... OtherCapabilityTs>
     constexpr basic_polymorphic(const basic_polymorphic<StorageT, OtherCapabilityTs...>& other)
-        : storage(other.entry(copy_t<StorageT>{})(other.get())), vtable_ptrs(other.entries()) {}
+        : storage(other.entry(copy_t<StorageT>{})(other.get())), witness_ptrs(other.entries()) {}
 
     template <std::derived_from<CapabilityTs>... OtherCapabilityTs>
     constexpr basic_polymorphic(basic_polymorphic<StorageT, OtherCapabilityTs...>&& other) noexcept
-        : storage(other.entry(move_t<StorageT>{})(std::move(other.get()))), vtable_ptrs(other.entries()) {}
+        : storage(other.entry(move_t<StorageT>{})(std::move(other.get()))), witness_ptrs(other.entries()) {}
 
     constexpr ~basic_polymorphic() { entry(destroy_t<StorageT>{})(storage); }
 
@@ -98,12 +98,12 @@ class basic_polymorphic {
     constexpr StorageT&&      get() && noexcept { return std::move(storage); }
     // constexpr const StorageT&& get() const&& noexcept { return std::move(storage); }
 
-    constexpr vtable_ptrs_type entries() const noexcept { return vtable_ptrs; }
+    constexpr witness_ptrs_type entries() const noexcept { return witness_ptrs; }
 
     template <capability CapabilityT>
         requires(... or std::derived_from<CapabilityTs, CapabilityT>)
     constexpr const signature<CapabilityT, StorageT>* entry(CapabilityT) const noexcept {
-        return vtable_ptrs->*&vtable<CapabilityT, StorageT>::entry;
+        return witness_ptrs->*&witness<CapabilityT, StorageT>::entry;
     }
 };
 

--- a/include/beman/any_view/detail/polymorphic.hpp
+++ b/include/beman/any_view/detail/polymorphic.hpp
@@ -42,11 +42,11 @@ class basic_polymorphic {
 
     template <std::derived_from<ProtocolTs>... OtherProtocolTs>
     constexpr basic_polymorphic(const basic_polymorphic<StorageT, OtherProtocolTs...>& other)
-        : storage(other.entry(copy_t<StorageT>{})(other.get())), witness_ptrs(other.entries()) {}
+        : storage(other.entry(copy_t<StorageT>{})(other.get())), witness_ptrs(other.witnesses()) {}
 
     template <std::derived_from<ProtocolTs>... OtherProtocolTs>
     constexpr basic_polymorphic(basic_polymorphic<StorageT, OtherProtocolTs...>&& other) noexcept
-        : storage(other.entry(move_t<StorageT>{})(std::move(other.get()))), witness_ptrs(other.entries()) {}
+        : storage(other.entry(move_t<StorageT>{})(std::move(other.get()))), witness_ptrs(other.witnesses()) {}
 
     constexpr ~basic_polymorphic() { entry(destroy_t<StorageT>{})(storage); }
 
@@ -98,7 +98,7 @@ class basic_polymorphic {
     constexpr StorageT&&      get() && noexcept { return std::move(storage); }
     // constexpr const StorageT&& get() const&& noexcept { return std::move(storage); }
 
-    constexpr witness_ptrs_type entries() const noexcept { return witness_ptrs; }
+    constexpr witness_ptrs_type witnesses() const noexcept { return witness_ptrs; }
 
     template <protocol ProtocolT>
         requires(... or std::derived_from<ProtocolTs, ProtocolT>)

--- a/include/beman/any_view/detail/polymorphic_iterator.hpp
+++ b/include/beman/any_view/detail/polymorphic_iterator.hpp
@@ -38,7 +38,7 @@ struct iter_cache<RefT> {
 template <class RefT>
 using iter_cache_t = typename iter_cache<RefT>::type;
 
-struct sentinel_compare_t : unary_capability {
+struct sentinel_compare_t : unary_protocol {
     template <not_adaptor T>
     static bool fn(const T& self);
 
@@ -49,7 +49,7 @@ struct sentinel_compare_t : unary_capability {
 };
 
 template <class RefT>
-struct dereference_t : unary_capability {
+struct dereference_t : unary_protocol {
     template <not_adaptor T>
     static RefT fn(const T& self);
 
@@ -60,7 +60,7 @@ struct dereference_t : unary_capability {
 };
 
 template <class RefT>
-struct cache_t : unary_capability {
+struct cache_t : unary_protocol {
     template <not_adaptor T>
     static iter_cache_t<RefT> fn(const T& self);
 
@@ -74,7 +74,7 @@ struct cache_t : unary_capability {
     }
 };
 
-struct increment_t : unary_capability {
+struct increment_t : unary_protocol {
     template <not_adaptor T>
     static void fn(T& self);
 
@@ -85,7 +85,7 @@ struct increment_t : unary_capability {
 };
 
 template <class RefT>
-struct next_t : unary_capability {
+struct next_t : unary_protocol {
     template <not_adaptor T>
     static iter_cache_t<RefT> fn(T& self);
 
@@ -96,7 +96,7 @@ struct next_t : unary_capability {
     }
 };
 
-struct decrement_t : unary_capability {
+struct decrement_t : unary_protocol {
     template <not_adaptor T>
     static void fn(T& self);
 
@@ -107,7 +107,7 @@ struct decrement_t : unary_capability {
 };
 
 template <class RefT>
-struct prev_t : unary_capability {
+struct prev_t : unary_protocol {
     template <not_adaptor T>
     static iter_cache_t<RefT> fn(T& self);
 
@@ -119,7 +119,7 @@ struct prev_t : unary_capability {
 };
 
 template <class RefT, class DiffT>
-struct dereference_at_t : unary_capability {
+struct dereference_at_t : unary_protocol {
     template <not_adaptor T>
     static RefT fn(const T& self, DiffT n);
 
@@ -130,7 +130,7 @@ struct dereference_at_t : unary_capability {
 };
 
 template <class RvalueRefT, class DiffT>
-struct iter_move_at_t : unary_capability {
+struct iter_move_at_t : unary_protocol {
     template <not_adaptor T>
     static RvalueRefT fn(const T& self, DiffT n);
 
@@ -141,7 +141,7 @@ struct iter_move_at_t : unary_capability {
 };
 
 template <class RefT, class DiffT>
-struct advance_t : unary_capability {
+struct advance_t : unary_protocol {
     template <not_adaptor T>
     static iter_cache_t<RefT> fn(T& self, DiffT n);
 
@@ -153,7 +153,7 @@ struct advance_t : unary_capability {
 };
 
 template <class RValueRefT>
-struct iter_move_t : unary_capability {
+struct iter_move_t : unary_protocol {
     template <not_adaptor T>
     static RValueRefT fn(const T& self);
 
@@ -163,7 +163,7 @@ struct iter_move_t : unary_capability {
     }
 };
 
-struct equality_compare_t : symmetric_binary_capability {
+struct equality_compare_t : symmetric_binary_protocol {
     [[nodiscard]] static constexpr bool default_value() noexcept { return false; }
 
     template <polymorphic PolyT>
@@ -178,7 +178,7 @@ struct equality_compare_t : symmetric_binary_capability {
     }
 };
 
-struct three_way_compare_t : symmetric_binary_capability {
+struct three_way_compare_t : symmetric_binary_protocol {
     [[nodiscard]] static constexpr std::partial_ordering default_value() noexcept {
         return std::partial_ordering::unordered;
     }
@@ -197,7 +197,7 @@ struct three_way_compare_t : symmetric_binary_capability {
 };
 
 template <class DiffT>
-struct subtract_t : symmetric_binary_capability {
+struct subtract_t : symmetric_binary_protocol {
     [[noreturn]] static DiffT default_value() { unreachable(); }
 
     template <polymorphic PolyT>
@@ -216,72 +216,70 @@ struct subtract_t : symmetric_binary_capability {
 using iterator_storage = small_storage<2 * sizeof(void*)>;
 
 template <class RefT, class RValueRefT>
-struct input_capabilities : inherit<move_t<iterator_storage>,
-                                    destroy_t<iterator_storage>,
-                                    dereference_t<RefT>,
-                                    iter_move_t<RValueRefT>,
-                                    increment_t,
-                                    sentinel_compare_t> {};
+struct input_protocol : inherit<move_t<iterator_storage>,
+                                destroy_t<iterator_storage>,
+                                dereference_t<RefT>,
+                                iter_move_t<RValueRefT>,
+                                increment_t,
+                                sentinel_compare_t> {};
 
 template <class RefT>
 concept has_cache = not std::same_as<iter_cache_t<RefT>, no_cache>;
 
 template <class RefT>
-struct forward_cache_capabilities : inherit<> {};
+struct forward_cache_protocol : inherit<> {};
 
 template <has_cache RefT>
-struct forward_cache_capabilities<RefT> : inherit<cache_t<RefT>, next_t<RefT>> {};
+struct forward_cache_protocol<RefT> : inherit<cache_t<RefT>, next_t<RefT>> {};
 
 template <class RefT, class RValueRefT>
-struct forward_capabilities : inherit<input_capabilities<RefT, RValueRefT>,
-                                      copy_t<iterator_storage>,
-                                      forward_cache_capabilities<RefT>,
-                                      type_t,
-                                      equality_compare_t> {};
+struct forward_protocol : inherit<input_protocol<RefT, RValueRefT>,
+                                  copy_t<iterator_storage>,
+                                  forward_cache_protocol<RefT>,
+                                  type_t,
+                                  equality_compare_t> {};
 
 template <class RefT>
-struct bidirectional_cache_capabilities : inherit<decrement_t> {};
+struct bidirectional_cache_protocol : inherit<decrement_t> {};
 
 template <has_cache RefT>
-struct bidirectional_cache_capabilities<RefT> : inherit<prev_t<RefT>> {};
+struct bidirectional_cache_protocol<RefT> : inherit<prev_t<RefT>> {};
 
 template <class RefT, class RValueRefT>
-struct bidirectional_capabilities
-    : inherit<forward_capabilities<RefT, RValueRefT>, bidirectional_cache_capabilities<RefT>> {};
+struct bidirectional_protocol : inherit<forward_protocol<RefT, RValueRefT>, bidirectional_cache_protocol<RefT>> {};
 
 template <class RefT, class RValueRefT, class DiffT>
-struct random_access_cache_capabilities : inherit<dereference_at_t<RefT, DiffT>, iter_move_at_t<RValueRefT, DiffT>> {};
+struct random_access_cache_protocol : inherit<dereference_at_t<RefT, DiffT>, iter_move_at_t<RValueRefT, DiffT>> {};
 
 template <has_cache RefT, class RValueRefT, class DiffT>
-struct random_access_cache_capabilities<RefT, RValueRefT, DiffT> : inherit<advance_t<RefT, DiffT>> {};
+struct random_access_cache_protocol<RefT, RValueRefT, DiffT> : inherit<advance_t<RefT, DiffT>> {};
 
 template <class RefT, class RValueRefT, class DiffT>
-struct random_access_capabilities : inherit<bidirectional_capabilities<RefT, RValueRefT>,
-                                            random_access_cache_capabilities<RefT, RValueRefT, DiffT>,
-                                            three_way_compare_t,
-                                            subtract_t<DiffT>> {};
+struct random_access_protocol : inherit<bidirectional_protocol<RefT, RValueRefT>,
+                                        random_access_cache_protocol<RefT, RValueRefT, DiffT>,
+                                        three_way_compare_t,
+                                        subtract_t<DiffT>> {};
 
 template <class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
-[[nodiscard]] consteval auto get_iterator_capabilities() {
+[[nodiscard]] consteval auto get_iterator_protocol() {
     using enum any_view_options;
 
     if constexpr (flag_is_set<OptsV, random_access>) {
-        return random_access_capabilities<RefT, RValueRefT, DiffT>{};
+        return random_access_protocol<RefT, RValueRefT, DiffT>{};
     } else if constexpr (flag_is_set<OptsV, bidirectional>) {
-        return bidirectional_capabilities<RefT, RValueRefT>{};
+        return bidirectional_protocol<RefT, RValueRefT>{};
     } else if constexpr (flag_is_set<OptsV, forward>) {
-        return forward_capabilities<RefT, RValueRefT>{};
+        return forward_protocol<RefT, RValueRefT>{};
     } else if constexpr (flag_is_set<OptsV, input>) {
-        return input_capabilities<RefT, RValueRefT>{};
+        return input_protocol<RefT, RValueRefT>{};
     }
 }
 
 template <class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
-using iterator_capabilities = decltype(get_iterator_capabilities<RefT, RValueRefT, DiffT, OptsV>());
+using iterator_protocol = decltype(get_iterator_protocol<RefT, RValueRefT, DiffT, OptsV>());
 
 template <class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
-using polymorphic_iterator =
-    basic_polymorphic<iterator_storage, iterator_capabilities<RefT, RValueRefT, DiffT, OptsV>>;
+using polymorphic_iterator = basic_polymorphic<iterator_storage, iterator_protocol<RefT, RValueRefT, DiffT, OptsV>>;
 
 } // namespace beman::any_view::detail
 

--- a/include/beman/any_view/detail/polymorphic_iterator.hpp
+++ b/include/beman/any_view/detail/polymorphic_iterator.hpp
@@ -216,36 +216,50 @@ struct subtract_t : symmetric_binary_capability {
 using iterator_storage = small_storage<2 * sizeof(void*)>;
 
 template <class RefT, class RValueRefT>
-using input_capabilities = inherit<move_t<iterator_storage>,
-                                   destroy_t<iterator_storage>,
-                                   dereference_t<RefT>,
-                                   iter_move_t<RValueRefT>,
-                                   increment_t,
-                                   sentinel_compare_t>;
+struct input_capabilities : inherit<move_t<iterator_storage>,
+                                    destroy_t<iterator_storage>,
+                                    dereference_t<RefT>,
+                                    iter_move_t<RValueRefT>,
+                                    increment_t,
+                                    sentinel_compare_t> {};
 
 template <class RefT>
-inline constexpr bool has_cache_v = not std::is_same_v<iter_cache_t<RefT>, no_cache>;
+concept has_cache = not std::same_as<iter_cache_t<RefT>, no_cache>;
+
+template <class RefT>
+struct forward_cache_capabilities : inherit<> {};
+
+template <has_cache RefT>
+struct forward_cache_capabilities<RefT> : inherit<cache_t<RefT>, next_t<RefT>> {};
 
 template <class RefT, class RValueRefT>
-using forward_capabilities =
-    inherit<input_capabilities<RefT, RValueRefT>,
-            copy_t<iterator_storage>,
-            std::conditional_t<has_cache_v<RefT>, inherit<cache_t<RefT>, next_t<RefT>>, inherit<>>,
-            type_t,
-            equality_compare_t>;
+struct forward_capabilities : inherit<input_capabilities<RefT, RValueRefT>,
+                                      copy_t<iterator_storage>,
+                                      forward_cache_capabilities<RefT>,
+                                      type_t,
+                                      equality_compare_t> {};
+
+template <class RefT>
+struct bidirectional_cache_capabilities : inherit<decrement_t> {};
+
+template <has_cache RefT>
+struct bidirectional_cache_capabilities<RefT> : inherit<prev_t<RefT>> {};
 
 template <class RefT, class RValueRefT>
-using bidirectional_capabilities =
-    inherit<forward_capabilities<RefT, RValueRefT>, std::conditional_t<has_cache_v<RefT>, prev_t<RefT>, decrement_t>>;
+struct bidirectional_capabilities
+    : inherit<forward_capabilities<RefT, RValueRefT>, bidirectional_cache_capabilities<RefT>> {};
 
 template <class RefT, class RValueRefT, class DiffT>
-using random_access_capabilities =
-    inherit<bidirectional_capabilities<RefT, RValueRefT>,
-            std::conditional_t<has_cache_v<RefT>,
-                               advance_t<RefT, DiffT>,
-                               inherit<dereference_at_t<RefT, DiffT>, iter_move_at_t<RValueRefT, DiffT>>>,
-            three_way_compare_t,
-            subtract_t<DiffT>>;
+struct random_access_cache_capabilities : inherit<dereference_at_t<RefT, DiffT>, iter_move_at_t<RValueRefT, DiffT>> {};
+
+template <has_cache RefT, class RValueRefT, class DiffT>
+struct random_access_cache_capabilities<RefT, RValueRefT, DiffT> : inherit<advance_t<RefT, DiffT>> {};
+
+template <class RefT, class RValueRefT, class DiffT>
+struct random_access_capabilities : inherit<bidirectional_capabilities<RefT, RValueRefT>,
+                                            random_access_cache_capabilities<RefT, RValueRefT, DiffT>,
+                                            three_way_compare_t,
+                                            subtract_t<DiffT>> {};
 
 template <class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
 [[nodiscard]] consteval auto get_iterator_capabilities() {

--- a/include/beman/any_view/detail/polymorphic_view.hpp
+++ b/include/beman/any_view/detail/polymorphic_view.hpp
@@ -100,8 +100,8 @@ template <class ValueT, std::common_reference_with<const ValueT&&> RefT>
 using const_reference_t = std::common_reference_t<const ValueT&&, RefT>;
 
 template <class ValueT, class RefT, class RValueRefT>
-concept const_capable = not std::same_as<const_reference_t<ValueT, RefT>, RefT> or
-                        not std::same_as<const_reference_t<ValueT, RValueRefT>, RValueRefT>;
+concept const_convertible = not std::same_as<const_reference_t<ValueT, RefT>, RefT> or
+                            not std::same_as<const_reference_t<ValueT, RValueRefT>, RValueRefT>;
 
 template <class DiffT, class...>
 struct const_protocol : inherit<> {};
@@ -129,7 +129,7 @@ struct sized_protocol : inherit<unsized_protocol, reserve_hint_t<DiffT>> {};
 
 template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV, class... ConstRefTs>
 consteval auto get_copyable_protocol() {
-    if constexpr (const_capable<ValueT, RefT, RValueRefT> and sizeof...(ConstRefTs) == 0) {
+    if constexpr (const_convertible<ValueT, RefT, RValueRefT> and sizeof...(ConstRefTs) == 0) {
         return get_copyable_protocol<ValueT,
                                      RefT,
                                      RValueRefT,

--- a/include/beman/any_view/detail/polymorphic_view.hpp
+++ b/include/beman/any_view/detail/polymorphic_view.hpp
@@ -9,20 +9,20 @@
 namespace beman::any_view::detail {
 
 template <class RefT, class RValueRefT, class DiffT>
-struct iterator_vtable_t : nullary_capability {
+struct iterator_witness_t : nullary_capability {
     template <any_view_options OptsV>
     using capabilities_for = iterator_capabilities<RefT, RValueRefT, DiffT, OptsV>;
 
-    using vtable_type = vtable<capabilities_for<any_view_options::input>, iterator_storage>;
+    using witness_type = witness<capabilities_for<any_view_options::input>, iterator_storage>;
 
     template <not_adaptor>
-    static const vtable_type* fn() noexcept;
+    static const witness_type* fn() noexcept;
 
     template <adaptor ViewAdaptorT>
-    [[nodiscard]] static constexpr const vtable_type* fn() noexcept {
+    [[nodiscard]] static constexpr const witness_type* fn() noexcept {
         using capability_type = capabilities_for<ViewAdaptorT::options>;
         using adaptor_type    = typename ViewAdaptorT::adaptor_type;
-        return std::addressof(vtable_for<capability_type, iterator_storage, adaptor_type>);
+        return std::addressof(witness_for<capability_type, iterator_storage, adaptor_type>);
     }
 };
 
@@ -56,23 +56,23 @@ struct reserve_hint_t : unary_capability {
 // inplace storage sufficient for a std::vector<T>
 using view_storage = small_storage<3 * sizeof(void*)>;
 
-template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
+template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV, class... ConstRefTs>
 consteval auto get_copyable_capabilities();
 
 template <class ConstRefT, class ConstRValueRefT, class DiffT>
-struct const_copyable_vtable_t : nullary_capability {
+struct const_copyable_witness_t : nullary_capability {
     template <any_view_options OptsV>
     using capabilities_for = decltype(get_copyable_capabilities<void, ConstRefT, ConstRValueRefT, DiffT, OptsV>());
 
-    using vtable_type = vtable<capabilities_for<any_view_options{}>, view_storage>;
+    using witness_type = witness<capabilities_for<any_view_options{}>, view_storage>;
 
     template <not_adaptor>
-    static const vtable_type* fn() noexcept;
+    static const witness_type* fn() noexcept;
 
     template <adaptor ViewAdaptorT>
-    [[nodiscard]] static constexpr const vtable_type* fn() noexcept {
+    [[nodiscard]] static constexpr const witness_type* fn() noexcept {
         using capability_type = capabilities_for<ViewAdaptorT::options>;
-        return std::addressof(vtable_for<capability_type, view_storage, ViewAdaptorT>);
+        return std::addressof(witness_for<capability_type, view_storage, ViewAdaptorT>);
     }
 };
 
@@ -80,68 +80,69 @@ template <class DiffT, any_view_options OptsV>
 consteval auto get_sized_capabilities();
 
 template <class ConstRefT, class ConstRValueRefT, class DiffT>
-struct const_sized_vtable_t : nullary_capability {
+struct const_sized_witness_t : nullary_capability {
     template <any_view_options OptsV>
     using capabilities_for = decltype(get_sized_capabilities<DiffT, OptsV>());
 
-    using vtable_type = vtable<capabilities_for<any_view_options{}>, view_storage>;
+    using witness_type = witness<capabilities_for<any_view_options{}>, view_storage>;
 
     template <not_adaptor>
-    static const vtable_type* fn() noexcept;
+    static const witness_type* fn() noexcept;
 
     template <adaptor ViewAdaptorT>
-    [[nodiscard]] static constexpr const vtable_type* fn() noexcept {
+    [[nodiscard]] static constexpr const witness_type* fn() noexcept {
         using capability_type = capabilities_for<ViewAdaptorT::options>;
-        return std::addressof(vtable_for<capability_type, view_storage, ViewAdaptorT>);
+        return std::addressof(witness_for<capability_type, view_storage, ViewAdaptorT>);
     }
 };
 
-template <class ValueT, class RefT>
+template <class ValueT, std::common_reference_with<const ValueT&&> RefT>
 using const_reference_t = std::common_reference_t<const ValueT&&, RefT>;
 
-template <class RefT, class ValueT>
-concept const_reference_with =
-    std::common_reference_with<RefT, const ValueT&&> and not std::same_as<RefT, const_reference_t<ValueT, RefT>>;
+template <class ValueT, class RefT, class RValueRefT>
+concept const_capable = not std::same_as<const_reference_t<ValueT, RefT>, RefT> or
+                        not std::same_as<const_reference_t<ValueT, RValueRefT>, RValueRefT>;
 
-template <class ValueT, class RefT, class RValueRefT, class DiffT>
-struct const_capabilities {
-    using type = inherit<>;
-};
+template <class DiffT, class...>
+struct const_capabilities : inherit<> {};
 
-template <class ValueT, const_reference_with<ValueT> RefT, const_reference_with<ValueT> RValueRefT, class DiffT>
-struct const_capabilities<ValueT, RefT, RValueRefT, DiffT> {
-    using reference        = const_reference_t<ValueT, RefT>;
-    using rvalue_reference = const_reference_t<ValueT, RValueRefT>;
-    using type             = inherit<const_copyable_vtable_t<reference, rvalue_reference, DiffT>,
-                                     const_sized_vtable_t<reference, rvalue_reference, DiffT>>;
-};
+template <class ConstRefT, class ConstRValueRefT, class DiffT>
+struct const_capabilities<ConstRefT, ConstRValueRefT, DiffT>
+    : inherit<const_copyable_witness_t<ConstRefT, ConstRValueRefT, DiffT>,
+              const_sized_witness_t<ConstRefT, ConstRValueRefT, DiffT>> {};
 
-template <class ValueT, class RefT, class RValueRefT, class DiffT>
-using const_capabilities_t = typename const_capabilities<ValueT, RefT, RValueRefT, DiffT>::type;
+template <class RefT, class RValueRefT, class DiffT, class... ConstRefTs>
+struct uncopyable_capabilities : inherit<move_t<view_storage>,
+                                         destroy_t<view_storage>,
+                                         iterator_witness_t<RefT, RValueRefT, DiffT>,
+                                         begin_t,
+                                         const_capabilities<ConstRefTs..., DiffT>> {};
 
-template <class ValueT, class RefT, class RValueRefT, class DiffT>
-using uncopyable_capabilities = inherit<move_t<view_storage>,
-                                        destroy_t<view_storage>,
-                                        iterator_vtable_t<RefT, RValueRefT, DiffT>,
-                                        begin_t,
-                                        const_capabilities_t<ValueT, RefT, RValueRefT, DiffT>>;
+template <class RefT, class RValueRefT, class DiffT, class... ConstRefTs>
+struct copyable_capabilities
+    : inherit<uncopyable_capabilities<RefT, RValueRefT, DiffT, ConstRefTs...>, copy_t<view_storage>> {};
 
-template <class ValueT, class RefT, class RValueRefT, class DiffT>
-using copyable_capabilities = inherit<uncopyable_capabilities<ValueT, RefT, RValueRefT, DiffT>, copy_t<view_storage>>;
-
-using unsized_capabilities = inherit<>;
+struct unsized_capabilities : inherit<> {};
 
 template <class DiffT>
-using sized_capabilities = inherit<unsized_capabilities, reserve_hint_t<DiffT>>;
+struct sized_capabilities : inherit<unsized_capabilities, reserve_hint_t<DiffT>> {};
 
-template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
+template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV, class... ConstRefTs>
 consteval auto get_copyable_capabilities() {
     using enum any_view_options;
 
-    if constexpr (flag_is_set<OptsV, copyable>) {
-        return copyable_capabilities<ValueT, RefT, RValueRefT, DiffT>{};
+    if constexpr (const_capable<ValueT, RefT, RValueRefT> and sizeof...(ConstRefTs) == 0) {
+        return get_copyable_capabilities<ValueT,
+                                         RefT,
+                                         RValueRefT,
+                                         DiffT,
+                                         OptsV,
+                                         const_reference_t<ValueT, RefT>,
+                                         const_reference_t<ValueT, RValueRefT>>();
+    } else if constexpr (flag_is_set<OptsV, copyable>) {
+        return copyable_capabilities<RefT, RValueRefT, DiffT, ConstRefTs...>{};
     } else {
-        return uncopyable_capabilities<ValueT, RefT, RValueRefT, DiffT>{};
+        return uncopyable_capabilities<RefT, RValueRefT, DiffT, ConstRefTs...>{};
     }
 }
 

--- a/include/beman/any_view/detail/polymorphic_view.hpp
+++ b/include/beman/any_view/detail/polymorphic_view.hpp
@@ -9,24 +9,24 @@
 namespace beman::any_view::detail {
 
 template <class RefT, class RValueRefT, class DiffT>
-struct iterator_witness_t : nullary_capability {
+struct iterator_witness_t : nullary_protocol {
     template <any_view_options OptsV>
-    using capabilities_for = iterator_capabilities<RefT, RValueRefT, DiffT, OptsV>;
+    using protocol_for = iterator_protocol<RefT, RValueRefT, DiffT, OptsV>;
 
-    using witness_type = witness<capabilities_for<any_view_options::input>, iterator_storage>;
+    using witness_type = witness<protocol_for<any_view_options::input>, iterator_storage>;
 
     template <not_adaptor>
     static const witness_type* fn() noexcept;
 
     template <adaptor ViewAdaptorT>
     [[nodiscard]] static constexpr const witness_type* fn() noexcept {
-        using capability_type = capabilities_for<ViewAdaptorT::options>;
-        using adaptor_type    = typename ViewAdaptorT::adaptor_type;
-        return std::addressof(witness_for<capability_type, iterator_storage, adaptor_type>);
+        using protocol_type = protocol_for<ViewAdaptorT::options>;
+        using adaptor_type  = typename ViewAdaptorT::adaptor_type;
+        return std::addressof(witness_for<protocol_type, iterator_storage, adaptor_type>);
     }
 };
 
-struct begin_t : unary_capability {
+struct begin_t : unary_protocol {
     template <not_adaptor T>
     static iterator_storage fn(T& self);
 
@@ -41,7 +41,7 @@ struct begin_t : unary_capability {
 };
 
 template <class DiffT>
-struct reserve_hint_t : unary_capability {
+struct reserve_hint_t : unary_protocol {
     using size_type = std::make_unsigned_t<DiffT>;
 
     template <not_adaptor T>
@@ -57,42 +57,42 @@ struct reserve_hint_t : unary_capability {
 using view_storage = small_storage<3 * sizeof(void*)>;
 
 template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV, class... ConstRefTs>
-consteval auto get_copyable_capabilities();
+consteval auto get_copyable_protocol();
 
 template <class ConstRefT, class ConstRValueRefT, class DiffT>
-struct const_copyable_witness_t : nullary_capability {
+struct const_copyable_witness_t : nullary_protocol {
     template <any_view_options OptsV>
-    using capabilities_for = decltype(get_copyable_capabilities<void, ConstRefT, ConstRValueRefT, DiffT, OptsV>());
+    using protocol_for = decltype(get_copyable_protocol<void, ConstRefT, ConstRValueRefT, DiffT, OptsV>());
 
-    using witness_type = witness<capabilities_for<any_view_options{}>, view_storage>;
+    using witness_type = witness<protocol_for<any_view_options{}>, view_storage>;
 
     template <not_adaptor>
     static const witness_type* fn() noexcept;
 
     template <adaptor ViewAdaptorT>
     [[nodiscard]] static constexpr const witness_type* fn() noexcept {
-        using capability_type = capabilities_for<ViewAdaptorT::options>;
-        return std::addressof(witness_for<capability_type, view_storage, ViewAdaptorT>);
+        using protocol_type = protocol_for<ViewAdaptorT::options>;
+        return std::addressof(witness_for<protocol_type, view_storage, ViewAdaptorT>);
     }
 };
 
 template <class DiffT, any_view_options OptsV>
-consteval auto get_sized_capabilities();
+consteval auto get_sized_protocol();
 
 template <class ConstRefT, class ConstRValueRefT, class DiffT>
-struct const_sized_witness_t : nullary_capability {
+struct const_sized_witness_t : nullary_protocol {
     template <any_view_options OptsV>
-    using capabilities_for = decltype(get_sized_capabilities<DiffT, OptsV>());
+    using protocol_for = decltype(get_sized_protocol<DiffT, OptsV>());
 
-    using witness_type = witness<capabilities_for<any_view_options{}>, view_storage>;
+    using witness_type = witness<protocol_for<any_view_options{}>, view_storage>;
 
     template <not_adaptor>
     static const witness_type* fn() noexcept;
 
     template <adaptor ViewAdaptorT>
     [[nodiscard]] static constexpr const witness_type* fn() noexcept {
-        using capability_type = capabilities_for<ViewAdaptorT::options>;
-        return std::addressof(witness_for<capability_type, view_storage, ViewAdaptorT>);
+        using protocol_type = protocol_for<ViewAdaptorT::options>;
+        return std::addressof(witness_for<protocol_type, view_storage, ViewAdaptorT>);
     }
 };
 
@@ -104,64 +104,59 @@ concept const_capable = not std::same_as<const_reference_t<ValueT, RefT>, RefT> 
                         not std::same_as<const_reference_t<ValueT, RValueRefT>, RValueRefT>;
 
 template <class DiffT, class...>
-struct const_capabilities : inherit<> {};
+struct const_protocol : inherit<> {};
 
 template <class ConstRefT, class ConstRValueRefT, class DiffT>
-struct const_capabilities<ConstRefT, ConstRValueRefT, DiffT>
+struct const_protocol<ConstRefT, ConstRValueRefT, DiffT>
     : inherit<const_copyable_witness_t<ConstRefT, ConstRValueRefT, DiffT>,
               const_sized_witness_t<ConstRefT, ConstRValueRefT, DiffT>> {};
 
 template <class RefT, class RValueRefT, class DiffT, class... ConstRefTs>
-struct uncopyable_capabilities : inherit<move_t<view_storage>,
-                                         destroy_t<view_storage>,
-                                         iterator_witness_t<RefT, RValueRefT, DiffT>,
-                                         begin_t,
-                                         const_capabilities<ConstRefTs..., DiffT>> {};
+struct uncopyable_protocol : inherit<move_t<view_storage>,
+                                     destroy_t<view_storage>,
+                                     iterator_witness_t<RefT, RValueRefT, DiffT>,
+                                     begin_t,
+                                     const_protocol<ConstRefTs..., DiffT>> {};
 
 template <class RefT, class RValueRefT, class DiffT, class... ConstRefTs>
-struct copyable_capabilities
-    : inherit<uncopyable_capabilities<RefT, RValueRefT, DiffT, ConstRefTs...>, copy_t<view_storage>> {};
+struct copyable_protocol : inherit<uncopyable_protocol<RefT, RValueRefT, DiffT, ConstRefTs...>, copy_t<view_storage>> {
+};
 
-struct unsized_capabilities : inherit<> {};
+struct unsized_protocol : inherit<> {};
 
 template <class DiffT>
-struct sized_capabilities : inherit<unsized_capabilities, reserve_hint_t<DiffT>> {};
+struct sized_protocol : inherit<unsized_protocol, reserve_hint_t<DiffT>> {};
 
 template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV, class... ConstRefTs>
-consteval auto get_copyable_capabilities() {
-    using enum any_view_options;
-
+consteval auto get_copyable_protocol() {
     if constexpr (const_capable<ValueT, RefT, RValueRefT> and sizeof...(ConstRefTs) == 0) {
-        return get_copyable_capabilities<ValueT,
-                                         RefT,
-                                         RValueRefT,
-                                         DiffT,
-                                         OptsV,
-                                         const_reference_t<ValueT, RefT>,
-                                         const_reference_t<ValueT, RValueRefT>>();
-    } else if constexpr (flag_is_set<OptsV, copyable>) {
-        return copyable_capabilities<RefT, RValueRefT, DiffT, ConstRefTs...>{};
+        return get_copyable_protocol<ValueT,
+                                     RefT,
+                                     RValueRefT,
+                                     DiffT,
+                                     OptsV,
+                                     const_reference_t<ValueT, RefT>,
+                                     const_reference_t<ValueT, RValueRefT>>();
+    } else if constexpr (flag_is_set<OptsV, any_view_options::copyable>) {
+        return copyable_protocol<RefT, RValueRefT, DiffT, ConstRefTs...>{};
     } else {
-        return uncopyable_capabilities<RefT, RValueRefT, DiffT, ConstRefTs...>{};
+        return uncopyable_protocol<RefT, RValueRefT, DiffT, ConstRefTs...>{};
     }
 }
 
 template <class DiffT, any_view_options OptsV>
-consteval auto get_sized_capabilities() {
-    using enum any_view_options;
-
-    if constexpr (flag_is_set<OptsV, approximately_sized>) {
-        return sized_capabilities<DiffT>{};
+consteval auto get_sized_protocol() {
+    if constexpr (flag_is_set<OptsV, any_view_options::approximately_sized>) {
+        return sized_protocol<DiffT>{};
     } else {
-        return unsized_capabilities{};
+        return unsized_protocol{};
     }
 }
 
 template <class ValueT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
-using polymorphic_view =
-    basic_polymorphic<view_storage,
-                      decltype(get_copyable_capabilities<ValueT, RefT, RValueRefT, DiffT, OptsV>()),
-                      decltype(get_sized_capabilities<DiffT, OptsV>())>;
+using polymorphic_view = basic_polymorphic<view_storage,
+                                           decltype(get_copyable_protocol<ValueT, RefT, RValueRefT, DiffT, OptsV>()),
+                                           decltype(get_sized_protocol<DiffT, OptsV>())>;
 
 } // namespace beman::any_view::detail
 

--- a/include/beman/any_view/detail/protocols.hpp
+++ b/include/beman/any_view/detail/protocols.hpp
@@ -3,7 +3,7 @@
 #ifndef BEMAN_ANY_VIEW_DETAIL_PROTOCOLS_HPP
 #define BEMAN_ANY_VIEW_DETAIL_PROTOCOLS_HPP
 
-#include <beman/any_view/detail/vtable.hpp>
+#include <beman/any_view/detail/witness.hpp>
 
 #include <typeinfo>
 #include <type_traits>

--- a/include/beman/any_view/detail/protocols.hpp
+++ b/include/beman/any_view/detail/protocols.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef BEMAN_ANY_VIEW_DETAIL_CAPABILITIES_HPP
-#define BEMAN_ANY_VIEW_DETAIL_CAPABILITIES_HPP
+#ifndef BEMAN_ANY_VIEW_DETAIL_PROTOCOLS_HPP
+#define BEMAN_ANY_VIEW_DETAIL_PROTOCOLS_HPP
 
 #include <beman/any_view/detail/vtable.hpp>
 
@@ -11,22 +11,22 @@
 
 namespace beman::any_view::detail {
 
-struct nullary_capability : capability_base {};
+struct nullary_protocol : protocol_base {};
 
-struct unary_capability : capability_base {};
+struct unary_protocol : protocol_base {};
 
-struct symmetric_binary_capability : capability_base {};
-
-template <class T>
-concept nullary = capability<T> and std::derived_from<T, nullary_capability>;
+struct symmetric_binary_protocol : protocol_base {};
 
 template <class T>
-concept unary = capability<T> and std::derived_from<T, unary_capability>;
+concept nullary = protocol<T> and std::derived_from<T, nullary_protocol>;
 
 template <class T>
-concept symmetric_binary = capability<T> and std::derived_from<T, symmetric_binary_capability>;
+concept unary = protocol<T> and std::derived_from<T, unary_protocol>;
 
-// bindings for nullary capabilities
+template <class T>
+concept symmetric_binary = protocol<T> and std::derived_from<T, symmetric_binary_protocol>;
+
+// bindings for nullary protocols
 template <nullary NullaryT, adaptor AdaptorT, storage StorageT, class RetT, class... ArgsT>
 struct bridge<thunk<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...)> {
     [[nodiscard]] static constexpr RetT fn(ArgsT... args) {
@@ -34,7 +34,7 @@ struct bridge<thunk<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...)> {
     }
 };
 
-// bindings for noexcept nullary capabilities
+// bindings for noexcept nullary protocols
 template <nullary NullaryT, adaptor AdaptorT, storage StorageT, class RetT, class... ArgsT>
 struct bridge<thunk<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...) noexcept> {
     [[nodiscard]] static constexpr RetT fn(ArgsT... args) noexcept {
@@ -42,7 +42,7 @@ struct bridge<thunk<NullaryT, AdaptorT>, StorageT, RetT(ArgsT...) noexcept> {
     }
 };
 
-// bindings for unary capabilities
+// bindings for unary protocols
 template <unary UnaryT, adaptor AdaptorT, storage StorageT, class RetT, class SelfT, class... ArgsT>
 struct bridge<thunk<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...)> {
     [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) {
@@ -51,7 +51,7 @@ struct bridge<thunk<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...)> {
     }
 };
 
-// bindings for noexcept unary capabilities
+// bindings for noexcept unary protocols
 template <unary UnaryT, adaptor AdaptorT, storage StorageT, class RetT, class SelfT, class... ArgsT>
 struct bridge<thunk<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...) noexcept> {
     [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) noexcept {
@@ -60,14 +60,14 @@ struct bridge<thunk<UnaryT, AdaptorT>, StorageT, RetT(SelfT, ArgsT...) noexcept>
     }
 };
 
-struct type_t : nullary_capability {
+struct type_t : nullary_protocol {
     template <class T>
     [[nodiscard]] static constexpr const std::type_info& fn() noexcept {
         return typeid(T);
     }
 };
 
-// bindings for symmetric binary capabilities
+// bindings for symmetric binary protocols
 template <symmetric_binary SymmetricBinaryT, adaptor AdaptorT, storage StorageT, class RetT>
 struct bridge<thunk<SymmetricBinaryT, AdaptorT>,
               StorageT,
@@ -86,7 +86,7 @@ struct bridge<thunk<SymmetricBinaryT, AdaptorT>,
     }
 };
 
-// dispatches to bindings for nullary capabilities
+// dispatches to bindings for nullary protocols
 template <nullary NullaryT, polymorphic PolyT, class RetT, class... ArgsT>
 struct bridge<NullaryT, PolyT, RetT(ArgsT...)> {
     [[nodiscard]] static constexpr RetT fn(const PolyT& self, ArgsT... args) {
@@ -94,7 +94,7 @@ struct bridge<NullaryT, PolyT, RetT(ArgsT...)> {
     }
 };
 
-// dispatches to bindings for noexcept nullary capabilities
+// dispatches to bindings for noexcept nullary protocols
 template <nullary NullaryT, polymorphic PolyT, class RetT, class... ArgsT>
 struct bridge<NullaryT, PolyT, RetT(ArgsT...) noexcept> {
     [[nodiscard]] static constexpr RetT fn(const PolyT& self, ArgsT... args) noexcept {
@@ -102,7 +102,7 @@ struct bridge<NullaryT, PolyT, RetT(ArgsT...) noexcept> {
     }
 };
 
-// dispatches to bindings for unary capabilities
+// dispatches to bindings for unary protocols
 template <unary UnaryT, polymorphic PolyT, class RetT, class SelfT, class... ArgsT>
 struct bridge<UnaryT, PolyT, RetT(SelfT, ArgsT...)> {
     [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) {
@@ -110,7 +110,7 @@ struct bridge<UnaryT, PolyT, RetT(SelfT, ArgsT...)> {
     }
 };
 
-// dispatches to bindings for noexcept unary capabilities
+// dispatches to bindings for noexcept unary protocols
 template <unary UnaryT, polymorphic PolyT, class RetT, class SelfT, class... ArgsT>
 struct bridge<UnaryT, PolyT, RetT(SelfT, ArgsT...) noexcept> {
     [[nodiscard]] static constexpr RetT fn(SelfT self, ArgsT... args) noexcept {
@@ -118,7 +118,7 @@ struct bridge<UnaryT, PolyT, RetT(SelfT, ArgsT...) noexcept> {
     }
 };
 
-// dispatches to bindings for symmetric binary capabilities
+// dispatches to bindings for symmetric binary protocols
 // requires type_t to be implemented
 template <symmetric_binary SymmetricBinaryT, polymorphic PolyT, class RetT>
 struct bridge<SymmetricBinaryT, PolyT, RetT(const PolyT&, const PolyT&)> {
@@ -128,7 +128,7 @@ struct bridge<SymmetricBinaryT, PolyT, RetT(const PolyT&, const PolyT&)> {
 };
 
 template <storage StorageT>
-struct move_t : nullary_capability {
+struct move_t : nullary_protocol {
     template <not_adaptor>
     static StorageT fn(StorageT&& source) noexcept;
 
@@ -139,7 +139,7 @@ struct move_t : nullary_capability {
 };
 
 template <storage StorageT>
-struct copy_t : nullary_capability {
+struct copy_t : nullary_protocol {
     template <not_adaptor>
     static StorageT fn(const StorageT& source);
 
@@ -150,7 +150,7 @@ struct copy_t : nullary_capability {
 };
 
 template <storage StorageT>
-struct destroy_t : nullary_capability {
+struct destroy_t : nullary_protocol {
     template <not_adaptor>
     static void fn(StorageT& source) noexcept;
 
@@ -162,4 +162,4 @@ struct destroy_t : nullary_capability {
 
 } // namespace beman::any_view::detail
 
-#endif // BEMAN_ANY_VIEW_DETAIL_CAPABILITIES_HPP
+#endif // BEMAN_ANY_VIEW_DETAIL_PROTOCOLS_HPP

--- a/include/beman/any_view/detail/small_storage.hpp
+++ b/include/beman/any_view/detail/small_storage.hpp
@@ -3,7 +3,7 @@
 #ifndef BEMAN_ANY_VIEW_DETAIL_SMALL_STORAGE_HPP
 #define BEMAN_ANY_VIEW_DETAIL_SMALL_STORAGE_HPP
 
-#include <beman/any_view/detail/vtable.hpp>
+#include <beman/any_view/detail/witness.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/include/beman/any_view/detail/vtable.hpp
+++ b/include/beman/any_view/detail/vtable.hpp
@@ -34,38 +34,59 @@ using signature = decltype(CapabilityT::template fn<T>);
 
 template <capability CapabilityT, class T, class SignatureT = signature<CapabilityT, T>>
     requires std::is_function_v<SignatureT>
-struct impl {
+struct bridge {
     static constexpr SignatureT* fn = CapabilityT::template fn<T>;
 };
 
 template <capability CapabilityT, class T>
-inline constexpr auto& dispatch = impl<CapabilityT, T>::fn;
+inline constexpr auto& dispatch = *bridge<CapabilityT, T>::fn;
 
 template <class... Ts>
-struct inherit : Ts... {};
+struct inherit : Ts... {
+    using base_type = inherit;
+};
+
+template <class T>
+using base_type_t = typename T::base_type;
+
+template <class T>
+concept derived_from_base_type = std::derived_from<T, base_type_t<T>>;
 
 template <class... Ts>
 inline constexpr bool enable_capability<inherit<Ts...>> = (... and capability<Ts>);
 
+template <derived_from_base_type T>
+inline constexpr bool enable_capability<T> = capability<base_type_t<T>>;
+
 template <capability CapabilityT, adaptor AdaptorT>
-struct binding : CapabilityT {};
+struct thunk : CapabilityT {};
 
 template <capability CapabilityT, storage StorageT>
-struct vtable {
+struct witness {
     signature<CapabilityT, StorageT>* entry;
 };
 
 template <capability... CapabilityTs, storage StorageT>
-struct vtable<inherit<CapabilityTs...>, StorageT> : vtable<CapabilityTs, StorageT>... {};
+struct witness<inherit<CapabilityTs...>, StorageT> : witness<CapabilityTs, StorageT>... {};
+
+template <capability CapabilityT, storage StorageT>
+    requires derived_from_base_type<CapabilityT>
+struct witness<CapabilityT, StorageT> : witness<base_type_t<CapabilityT>, StorageT> {};
 
 template <capability CapabilityT, storage StorageT, adaptor AdaptorT>
-inline constexpr vtable<CapabilityT, StorageT> vtable_for{
-    .entry = dispatch<binding<CapabilityT, AdaptorT>, StorageT>,
+inline constexpr witness<CapabilityT, StorageT> witness_for{
+    .entry = dispatch<thunk<CapabilityT, AdaptorT>, StorageT>,
 };
 
 template <capability... CapabilityTs, storage StorageT, adaptor AdaptorT>
-inline constexpr vtable<inherit<CapabilityTs...>, StorageT> vtable_for<inherit<CapabilityTs...>, StorageT, AdaptorT>{
-    vtable_for<CapabilityTs, StorageT, AdaptorT>...,
+inline constexpr witness<inherit<CapabilityTs...>, StorageT> witness_for<inherit<CapabilityTs...>, StorageT, AdaptorT>{
+    witness_for<CapabilityTs, StorageT, AdaptorT>...,
+};
+
+template <capability CapabilityT, storage StorageT, adaptor AdaptorT>
+    requires derived_from_base_type<CapabilityT>
+inline constexpr witness<CapabilityT, StorageT> witness_for<CapabilityT, StorageT, AdaptorT>{
+    witness_for<base_type_t<CapabilityT>, StorageT, AdaptorT>,
 };
 
 } // namespace beman::any_view::detail

--- a/include/beman/any_view/detail/vtable.hpp
+++ b/include/beman/any_view/detail/vtable.hpp
@@ -9,10 +9,10 @@
 
 namespace beman::any_view::detail {
 
-struct capability_base {};
+struct protocol_base {};
 
 template <class T>
-inline constexpr bool enable_capability = std::derived_from<T, capability_base>;
+inline constexpr bool enable_protocol = std::derived_from<T, protocol_base>;
 
 template <class T>
 inline constexpr bool enable_storage = false;
@@ -21,7 +21,7 @@ template <class T>
 inline constexpr bool enable_polymorphic = false;
 
 template <class T>
-concept capability = std::is_empty_v<T> and enable_capability<T>;
+concept protocol = std::is_empty_v<T> and enable_protocol<T>;
 
 template <class T>
 concept storage = enable_storage<T>;
@@ -29,17 +29,17 @@ concept storage = enable_storage<T>;
 template <class T>
 concept polymorphic = enable_polymorphic<T>;
 
-template <capability CapabilityT, class T>
-using signature = decltype(CapabilityT::template fn<T>);
+template <protocol ProtocolT, class T>
+using signature = decltype(ProtocolT::template fn<T>);
 
-template <capability CapabilityT, class T, class SignatureT = signature<CapabilityT, T>>
+template <protocol ProtocolT, class T, class SignatureT = signature<ProtocolT, T>>
     requires std::is_function_v<SignatureT>
 struct bridge {
-    static constexpr SignatureT* fn = CapabilityT::template fn<T>;
+    static constexpr SignatureT* fn = ProtocolT::template fn<T>;
 };
 
-template <capability CapabilityT, class T>
-inline constexpr auto& dispatch = *bridge<CapabilityT, T>::fn;
+template <protocol ProtocolT, class T>
+inline constexpr auto& dispatch = *bridge<ProtocolT, T>::fn;
 
 template <class... Ts>
 struct inherit : Ts... {
@@ -53,40 +53,40 @@ template <class T>
 concept derived_from_base_type = std::derived_from<T, base_type_t<T>>;
 
 template <class... Ts>
-inline constexpr bool enable_capability<inherit<Ts...>> = (... and capability<Ts>);
+inline constexpr bool enable_protocol<inherit<Ts...>> = (... and protocol<Ts>);
 
 template <derived_from_base_type T>
-inline constexpr bool enable_capability<T> = capability<base_type_t<T>>;
+inline constexpr bool enable_protocol<T> = protocol<base_type_t<T>>;
 
-template <capability CapabilityT, adaptor AdaptorT>
-struct thunk : CapabilityT {};
+template <protocol ProtocolT, adaptor AdaptorT>
+struct thunk : ProtocolT {};
 
-template <capability CapabilityT, storage StorageT>
+template <protocol ProtocolT, storage StorageT>
 struct witness {
-    signature<CapabilityT, StorageT>* entry;
+    signature<ProtocolT, StorageT>* entry;
 };
 
-template <capability... CapabilityTs, storage StorageT>
-struct witness<inherit<CapabilityTs...>, StorageT> : witness<CapabilityTs, StorageT>... {};
+template <protocol... ProtocolTs, storage StorageT>
+struct witness<inherit<ProtocolTs...>, StorageT> : witness<ProtocolTs, StorageT>... {};
 
-template <capability CapabilityT, storage StorageT>
-    requires derived_from_base_type<CapabilityT>
-struct witness<CapabilityT, StorageT> : witness<base_type_t<CapabilityT>, StorageT> {};
+template <protocol ProtocolT, storage StorageT>
+    requires derived_from_base_type<ProtocolT>
+struct witness<ProtocolT, StorageT> : witness<base_type_t<ProtocolT>, StorageT> {};
 
-template <capability CapabilityT, storage StorageT, adaptor AdaptorT>
-inline constexpr witness<CapabilityT, StorageT> witness_for{
-    .entry = dispatch<thunk<CapabilityT, AdaptorT>, StorageT>,
+template <protocol ProtocolT, storage StorageT, adaptor AdaptorT>
+inline constexpr witness<ProtocolT, StorageT> witness_for{
+    .entry = dispatch<thunk<ProtocolT, AdaptorT>, StorageT>,
 };
 
-template <capability... CapabilityTs, storage StorageT, adaptor AdaptorT>
-inline constexpr witness<inherit<CapabilityTs...>, StorageT> witness_for<inherit<CapabilityTs...>, StorageT, AdaptorT>{
-    witness_for<CapabilityTs, StorageT, AdaptorT>...,
+template <protocol... ProtocolTs, storage StorageT, adaptor AdaptorT>
+inline constexpr witness<inherit<ProtocolTs...>, StorageT> witness_for<inherit<ProtocolTs...>, StorageT, AdaptorT>{
+    witness_for<ProtocolTs, StorageT, AdaptorT>...,
 };
 
-template <capability CapabilityT, storage StorageT, adaptor AdaptorT>
-    requires derived_from_base_type<CapabilityT>
-inline constexpr witness<CapabilityT, StorageT> witness_for<CapabilityT, StorageT, AdaptorT>{
-    witness_for<base_type_t<CapabilityT>, StorageT, AdaptorT>,
+template <protocol ProtocolT, storage StorageT, adaptor AdaptorT>
+    requires derived_from_base_type<ProtocolT>
+inline constexpr witness<ProtocolT, StorageT> witness_for<ProtocolT, StorageT, AdaptorT>{
+    witness_for<base_type_t<ProtocolT>, StorageT, AdaptorT>,
 };
 
 } // namespace beman::any_view::detail

--- a/include/beman/any_view/detail/witness.hpp
+++ b/include/beman/any_view/detail/witness.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef BEMAN_ANY_VIEW_DETAIL_VTABLE_HPP
-#define BEMAN_ANY_VIEW_DETAIL_VTABLE_HPP
+#ifndef BEMAN_ANY_VIEW_DETAIL_WITNESS_HPP
+#define BEMAN_ANY_VIEW_DETAIL_WITNESS_HPP
 
 #include <beman/any_view/detail/adaptors.hpp>
 
@@ -39,24 +39,24 @@ struct bridge {
 };
 
 template <protocol ProtocolT, class T>
-inline constexpr auto& dispatch = *bridge<ProtocolT, T>::fn;
+inline constexpr auto dispatch = bridge<ProtocolT, T>::fn;
 
 template <class... Ts>
 struct inherit : Ts... {
-    using base_type = inherit;
+    using inherit_type = inherit;
 };
 
 template <class T>
-using base_type_t = typename T::base_type;
+using inherit_type_t = typename T::inherit_type;
 
 template <class T>
-concept derived_from_base_type = std::derived_from<T, base_type_t<T>>;
+concept derived_from_inherit = std::derived_from<T, inherit_type_t<T>>;
 
 template <class... Ts>
 inline constexpr bool enable_protocol<inherit<Ts...>> = (... and protocol<Ts>);
 
-template <derived_from_base_type T>
-inline constexpr bool enable_protocol<T> = protocol<base_type_t<T>>;
+template <derived_from_inherit T>
+inline constexpr bool enable_protocol<T> = protocol<inherit_type_t<T>>;
 
 template <protocol ProtocolT, adaptor AdaptorT>
 struct thunk : ProtocolT {};
@@ -70,8 +70,8 @@ template <protocol... ProtocolTs, storage StorageT>
 struct witness<inherit<ProtocolTs...>, StorageT> : witness<ProtocolTs, StorageT>... {};
 
 template <protocol ProtocolT, storage StorageT>
-    requires derived_from_base_type<ProtocolT>
-struct witness<ProtocolT, StorageT> : witness<base_type_t<ProtocolT>, StorageT> {};
+    requires derived_from_inherit<ProtocolT>
+struct witness<ProtocolT, StorageT> : witness<inherit_type_t<ProtocolT>, StorageT> {};
 
 template <protocol ProtocolT, storage StorageT, adaptor AdaptorT>
 inline constexpr witness<ProtocolT, StorageT> witness_for{
@@ -84,11 +84,11 @@ inline constexpr witness<inherit<ProtocolTs...>, StorageT> witness_for<inherit<P
 };
 
 template <protocol ProtocolT, storage StorageT, adaptor AdaptorT>
-    requires derived_from_base_type<ProtocolT>
+    requires derived_from_inherit<ProtocolT>
 inline constexpr witness<ProtocolT, StorageT> witness_for<ProtocolT, StorageT, AdaptorT>{
-    witness_for<base_type_t<ProtocolT>, StorageT, AdaptorT>,
+    witness_for<inherit_type_t<ProtocolT>, StorageT, AdaptorT>,
 };
 
 } // namespace beman::any_view::detail
 
-#endif // BEMAN_ANY_VIEW_DETAIL_VTABLE_HPP
+#endif // BEMAN_ANY_VIEW_DETAIL_WITNESS_HPP


### PR DESCRIPTION
Instead of using type aliases that expand to very large nested template specializations, added support for strong types to shorten typenames in debug strings.

Also renamed implementation details for clarity:
- `capability` -> `protocol`
- `vtable` -> `witness`
- `impl` -> `bridge`
- `binding` -> `thunk`