### PR TITLE
Bugfix: sync unsized contiguous iterator with cache

### DIFF
--- a/include/beman/any_view/detail/iterator.hpp
+++ b/include/beman/any_view/detail/iterator.hpp
@@ -135,6 +135,9 @@ class iterator : public iterator_category_type<iterator_concept_t<OptsV>, std::i
     constexpr iterator& operator++() {
         if constexpr (contiguous or has_index) {
             ++cache_or_index;
+            if constexpr (contiguous) {
+                dispatch<sync_t<RefT>>(poly, cache_or_index);
+            }
         } else if constexpr (has_cache) {
             cache_or_index = dispatch<next_t<RefT>>(poly);
         } else {
@@ -168,6 +171,9 @@ class iterator : public iterator_category_type<iterator_concept_t<OptsV>, std::i
     {
         if constexpr (contiguous or has_index) {
             --cache_or_index;
+            if constexpr (contiguous) {
+                dispatch<sync_t<RefT>>(poly, cache_or_index);
+            }
         } else if constexpr (has_cache) {
             cache_or_index = dispatch<prev_t<RefT>>(poly);
         } else {
@@ -209,6 +215,9 @@ class iterator : public iterator_category_type<iterator_concept_t<OptsV>, std::i
     {
         if constexpr (contiguous or has_index) {
             cache_or_index += offset;
+            if constexpr (contiguous) {
+                dispatch<sync_t<RefT>>(poly, cache_or_index);
+            }
         } else {
             static_assert(has_cache, "random access iterator with no index has cache");
             cache_or_index = dispatch<advance_t<RefT, DiffT>>(poly, offset);

--- a/include/beman/any_view/detail/polymorphic_iterator.hpp
+++ b/include/beman/any_view/detail/polymorphic_iterator.hpp
@@ -163,6 +163,18 @@ struct iter_move_t : unary_protocol {
     }
 };
 
+template <class RefT>
+struct sync_t : unary_protocol {
+    template <not_adaptor T>
+    static void fn(T& self, iter_cache_t<RefT> cache);
+
+    template <adaptor IteratorAdaptorT>
+    static constexpr void fn(IteratorAdaptorT& adaptor, iter_cache_t<RefT> cache) {
+        const auto n = cache - std::to_address(adaptor.iterator);
+        adaptor.iterator += n;
+    }
+};
+
 struct equality_compare_t : symmetric_binary_protocol {
     [[nodiscard]] static constexpr bool default_value() noexcept { return false; }
 
@@ -260,11 +272,16 @@ struct random_access_protocol : inherit<bidirectional_protocol<RefT, RValueRefT>
                                         three_way_compare_t,
                                         subtract_t<DiffT>> {};
 
+template <class RefT, class RValueRefT, class DiffT>
+struct contiguous_protocol : inherit<random_access_protocol<RefT, RValueRefT, DiffT>, sync_t<RefT>> {};
+
 template <class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
 [[nodiscard]] consteval auto get_iterator_protocol() {
     using enum any_view_options;
 
-    if constexpr (flag_is_set<OptsV, random_access>) {
+    if constexpr (flag_is_set<OptsV, contiguous>) {
+        return contiguous_protocol<RefT, RValueRefT, DiffT>{};
+    } else if constexpr (flag_is_set<OptsV, random_access>) {
         return random_access_protocol<RefT, RValueRefT, DiffT>{};
     } else if constexpr (flag_is_set<OptsV, bidirectional>) {
         return bidirectional_protocol<RefT, RValueRefT>{};


### PR DESCRIPTION
Contiguous iterators dispatch on `sentinel_compare_t` to determine whether to end iteration, but the target iterator's state is not updated when advancing because only the cache is used.

This introduces a contiguous iterator protocol `sync_t` to synchronize the target iterator state with the cache object when advancing, so that when dispatching on `sentinel_compare_t`, the target iterator is in the correct state.