### PR TITLE
Fixed readme.title in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# beman.any_view: <short_description>
 <!--
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# beman.any_view: <short_description>
+# beman.any_view: A generalized type-erased view with customizable properties
+
 <!--
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
-
-# beman.any_view: A generalized type-erased view with customizable properties
 
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg)
 ![Continuous Integration Tests](https://github.com/bemanproject/any_view/actions/workflows/ci_tests.yml/badge.svg)


### PR DESCRIPTION
[bemanproject/beman-tidy#250](https://github.com/bemanproject/beman-tidy/issues/250)
I fixed the first line in the README.md to be '# beman.any_view: A generalized type-erased view with customizable properties'.

```
# beman.any_view: A generalized type-erased view with customizable properties
```

