### PR TITLE
Added the Compiler Explorer Badge in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ![Continuous Integration Tests](https://github.com/bemanproject/any_view/actions/workflows/ci_tests.yml/badge.svg)
 ![Lint Check (pre-commit)](https://github.com/bemanproject/any_view/actions/workflows/pre-commit.yml/badge.svg)
 ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
+[![Compiler Explorer Example](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/Y5hefMj65)
 
 **Implements**: `std::ranges::any_view` proposed in [any_view (P3411)](https://wg21.link/p3411).
 


### PR DESCRIPTION
[bemanproject/beman-tidy#250](https://github.com/bemanproject/beman-tidy/issues/250)

Before:

```bash
Running check [Requirement][release.godbolt_trunk_version] ... 
[error][release.godbolt_trunk_version]: The file 'README.md' does not contain a Compiler Explorer badge - trunk version assumed to be missing.
        check [Requirement][release.godbolt_trunk_version] ... failed
```
After:

```bash
Running check [Recommendation][release.godbolt_trunk_version] ... 
        check [Recommendation][release.godbolt_trunk_version] ... passed
```