### PR TITLE
Fix clang-format

### DIFF
--- a/include/beman/any_view/detail/compressed_ptr.hpp
+++ b/include/beman/any_view/detail/compressed_ptr.hpp
@@ -33,7 +33,7 @@ class compressed_ptr<T> {
 #if _MSC_VER
     template <class MemberT, class BaseT>
         requires std::derived_from<T, BaseT>
-    [[nodiscard]] constexpr const MemberT& operator->*(MemberT BaseT::*member_ptr) const noexcept {
+    [[nodiscard]] constexpr const MemberT& operator->*(MemberT BaseT::* member_ptr) const noexcept {
         return value->*member_ptr;
     }
 #endif // _MSC_VER

--- a/include/beman/any_view/detail/no_unique_address.hpp
+++ b/include/beman/any_view/detail/no_unique_address.hpp
@@ -4,11 +4,11 @@
 #define BEMAN_ANY_VIEW_DETAIL_NO_UNIQUE_ADDRESS_HPP
 
 #ifndef BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS
-#if _MSC_VER
-#define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
-#else
-#define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS [[no_unique_address]]
-#endif // _MSC_VER
-#endif // BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS
+    #if _MSC_VER
+        #define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+    #else
+        #define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS [[no_unique_address]]
+    #endif // _MSC_VER
+#endif     // BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS
 
 #endif // BEMAN_ANY_VIEW_DETAIL_NO_UNIQUE_ADDRESS_HPP

--- a/include/beman/any_view/detail/reference_converts_from_temporary.hpp
+++ b/include/beman/any_view/detail/reference_converts_from_temporary.hpp
@@ -9,14 +9,14 @@ template <class T, class U>
 inline constexpr bool reference_converts_from_temporary_v = false;
 
 #ifdef __has_builtin
-#if __has_builtin(__reference_converts_from_temporary)
+    #if __has_builtin(__reference_converts_from_temporary)
 
 template <class T, class U>
     requires true
 inline constexpr bool reference_converts_from_temporary_v<T, U> = __reference_converts_from_temporary(T, U);
 
-#endif // __has_builtin(__reference_converts_from_temporary)
-#endif // __has_builtin
+    #endif // __has_builtin(__reference_converts_from_temporary)
+#endif     // __has_builtin
 
 } // namespace beman::any_view::detail
 

--- a/tests/beman/any_view/sfinae.test.cpp
+++ b/tests/beman/any_view/sfinae.test.cpp
@@ -93,11 +93,11 @@ TEST(SfinaeTest, span) {
 
 TEST(SfinaeTest, iota) {
 #ifdef __has_builtin
-#if __has_builtin(__reference_converts_from_temporary)
+    #if __has_builtin(__reference_converts_from_temporary)
     // Prevention of dangling references requires C++23 compiler support
     static_assert(not std::constructible_from<any_view<const int>, std::ranges::iota_view<int>>);
-#endif // __has_builtin(__reference_converts_from_temporary)
-#endif // __has_builtin
+    #endif // __has_builtin(__reference_converts_from_temporary)
+#endif     // __has_builtin
     static_assert(std::constructible_from<any_view<int, random_access, int>, std::ranges::iota_view<int>>);
     static_assert(
         not std::constructible_from<any_view<int, input | approximately_sized, int>, std::ranges::iota_view<int>>);


### PR DESCRIPTION
785cd9894b3fe8d01b9c2bcdf33fc621e758cf4e updated the clang-format version and configuration but did not re-run clang-format, breaking the CI check on master. This commit addresses the issue by checking in the results of a clang-format run.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
