### PR TITLE
Don't use ednolan fork of benchmark

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -12,8 +12,8 @@
     {
       "name": "benchmark",
       "package_name": "benchmark",
-      "git_repository": "https://github.com/ednolan/benchmark.git",
-      "git_tag": "1e122ad5693ee068a6133f7df67805c4cacfe64d",
+      "git_repository": "https://github.com/google/benchmark.git",
+      "git_tag": "v1.9.5",
       "cmake_args": {
         "BENCHMARK_ENABLE_WERROR": "OFF"
       }


### PR DESCRIPTION
Problems with CI that I thought were caused by benchmark were actually just caused by using too old a benchmark version and are already fixed in the latest version.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
