### PR TITLE
Non-const size and reserve_hint

### DIFF
--- a/include/beman/any_view/any_view.hpp
+++ b/include/beman/any_view/any_view.hpp
@@ -187,13 +187,13 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
 
     [[nodiscard]] constexpr sentinel end() { return std::default_sentinel; }
 
-    [[nodiscard]] constexpr size_type size() const
+    [[nodiscard]] constexpr size_type size()
         requires sized
     {
         return dispatch<detail::reserve_hint_t<DiffT>>(poly);
     }
 
-    [[nodiscard]] constexpr size_type reserve_hint() const
+    [[nodiscard]] constexpr size_type reserve_hint()
         requires approximately_sized
     {
         return dispatch<detail::reserve_hint_t<DiffT>>(poly);


### PR DESCRIPTION
This makes `size()` and `reserve_hint()` member functions non-const in order to erase views like `drop_while_view<V>` where `V` is a `random_access_range`. Because it caches the begin iterator, and the size computation is based on the difference between the sentinel and the cached iterator, the `size()` member is non-const, the `size()` member of `any_view` must also be non-const to erase it.