### PR TITLE
Mandate rather than constrain movable and copyable

### DIFF
--- a/include/beman/any_view/concepts.hpp
+++ b/include/beman/any_view/concepts.hpp
@@ -27,29 +27,9 @@ concept any_compatible_sized_range =
 
 template <class RangeT, any_view_options OptsV>
 concept any_compatible_borrowed_range =
-    not flag_is_set<OptsV, any_view_options::borrowed> or std::ranges::borrowed_range<RangeT>;
-
-template <class ViewT, any_view_options OptsV>
-concept any_compatible_copyable_view = not flag_is_set<OptsV, any_view_options::copyable> or std::copyable<ViewT>;
-
-template <class ViewT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
-concept any_compatible_view =
-    any_compatible_iterator<std::ranges::iterator_t<ViewT>, RefT, RValueRefT, DiffT, OptsV> and
-    any_compatible_sized_range<ViewT, OptsV> and any_compatible_borrowed_range<ViewT, OptsV>;
-
-template <class RangeT>
-struct make_view {
-    using type = std::views::all_t<RangeT>;
-};
-
-template <class RangeT>
-    requires std::ranges::enable_view<std::remove_cvref_t<RangeT>>
-struct make_view<RangeT> {
-    using type = std::remove_cvref_t<RangeT>;
-};
-
-template <class RangeT>
-using make_view_t = typename make_view<RangeT>::type;
+    not flag_is_set<OptsV, any_view_options::borrowed> or
+    (not std::ranges::enable_view<std::remove_cvref_t<RangeT>> and std::is_lvalue_reference_v<RangeT>) or
+    std::ranges::enable_borrowed_range<std::remove_cvref_t<RangeT>>;
 
 template <class T, class U>
 concept different_from = not std::same_as<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
@@ -59,9 +39,8 @@ concept different_from = not std::same_as<std::remove_cvref_t<T>, std::remove_cv
 template <class RangeT, class RefT, class RValueRefT, class DiffT, any_view_options OptsV>
 concept ext_any_compatible_range =
     std::ranges::range<RangeT> and
-    detail::any_compatible_view<detail::make_view_t<RangeT>, RefT, RValueRefT, DiffT, OptsV> and
-    (std::ranges::enable_view<std::remove_cvref_t<RangeT>> or
-     detail::any_compatible_copyable_view<detail::make_view_t<RangeT>, OptsV>);
+    detail::any_compatible_iterator<std::ranges::iterator_t<RangeT>, RefT, RValueRefT, DiffT, OptsV> and
+    detail::any_compatible_sized_range<RangeT, OptsV> and detail::any_compatible_borrowed_range<RangeT, OptsV>;
 
 } // namespace beman::any_view
 

--- a/tests/beman/any_view/sfinae.test.cpp
+++ b/tests/beman/any_view/sfinae.test.cpp
@@ -31,7 +31,11 @@ TEST(SfinaeTest, forward_list) {
     static_assert(not std::constructible_from<any_view<int, input | approximately_sized>, std::forward_list<int>>);
     static_assert(not std::constructible_from<any_view<int, input | sized>, std::forward_list<int>>);
     static_assert(not std::constructible_from<any_view<int, input | borrowed>, std::forward_list<int>>);
-    static_assert(not std::constructible_from<any_view<int, input | copyable>, std::forward_list<int>>);
+#ifndef _MSC_VER
+    // error C2280: attempting to reference a deleted function
+    // copyable is mandated, not required
+    static_assert(std::constructible_from<any_view<int, input | copyable>, std::forward_list<int>>);
+#endif
 
     static_assert(std::constructible_from<any_view<int, input | borrowed>, std::forward_list<int>&>);
     static_assert(std::constructible_from<any_view<int, input | copyable>, std::forward_list<int>&>);
@@ -43,7 +47,11 @@ TEST(SfinaeTest, list) {
     static_assert(std::constructible_from<any_view<int, input | approximately_sized>, std::list<int>>);
     static_assert(std::constructible_from<any_view<int, input | sized>, std::list<int>>);
     static_assert(not std::constructible_from<any_view<int, input | borrowed>, std::list<int>>);
-    static_assert(not std::constructible_from<any_view<int, input | copyable>, std::list<int>>);
+#ifndef _MSC_VER
+    // error C2280: attempting to reference a deleted function
+    // copyable is mandated, not required
+    static_assert(std::constructible_from<any_view<int, input | copyable>, std::list<int>>);
+#endif
 
     static_assert(std::constructible_from<any_view<int, input | borrowed>, std::list<int>&>);
     static_assert(std::constructible_from<any_view<int, input | copyable>, std::list<int>&>);
@@ -55,7 +63,11 @@ TEST(SfinaeTest, deque) {
     static_assert(std::constructible_from<any_view<int, input | approximately_sized>, std::deque<int>>);
     static_assert(std::constructible_from<any_view<int, input | sized>, std::deque<int>>);
     static_assert(not std::constructible_from<any_view<int, input | borrowed>, std::deque<int>>);
-    static_assert(not std::constructible_from<any_view<int, input | copyable>, std::deque<int>>);
+#ifndef _MSC_VER
+    // error C2280: attempting to reference a deleted function
+    // copyable is mandated, not required
+    static_assert(std::constructible_from<any_view<int, input | copyable>, std::deque<int>>);
+#endif
 
     static_assert(std::constructible_from<any_view<int, input | borrowed>, std::deque<int>&>);
     static_assert(std::constructible_from<any_view<int, input | copyable>, std::deque<int>&>);
@@ -66,7 +78,11 @@ TEST(SfinaeTest, vector) {
     static_assert(std::constructible_from<any_view<int, input | approximately_sized>, std::vector<int>>);
     static_assert(std::constructible_from<any_view<int, input | sized>, std::vector<int>>);
     static_assert(not std::constructible_from<any_view<int, input | borrowed>, std::vector<int>>);
-    static_assert(not std::constructible_from<any_view<int, input | copyable>, std::vector<int>>);
+#ifndef _MSC_VER
+    // error C2280: attempting to reference a deleted function
+    // copyable is mandated, not required
+    static_assert(std::constructible_from<any_view<int, input | copyable>, std::vector<int>>);
+#endif
 
     static_assert(std::constructible_from<any_view<int, input | borrowed>, std::vector<int>&>);
     static_assert(std::constructible_from<any_view<int, input | copyable>, std::vector<int>&>);
@@ -77,7 +93,11 @@ TEST(SfinaeTest, vector_of_bool) {
     static_assert(std::constructible_from<any_view<bool, input | approximately_sized, bool>, std::vector<bool>>);
     static_assert(std::constructible_from<any_view<bool, input | sized, bool>, std::vector<bool>>);
     static_assert(not std::constructible_from<any_view<bool, input | borrowed, bool>, std::vector<bool>>);
-    static_assert(not std::constructible_from<any_view<bool, input | copyable, bool>, std::vector<bool>>);
+#ifndef _MSC_VER
+    // error C2280: attempting to reference a deleted function
+    // copyable is mandated, not required
+    static_assert(std::constructible_from<any_view<bool, input | copyable, bool>, std::vector<bool>>);
+#endif
 
     static_assert(std::constructible_from<any_view<bool, input | borrowed, bool>, std::vector<bool>&>);
     static_assert(std::constructible_from<any_view<bool, input | copyable, bool>, std::vector<bool>&>);
@@ -109,10 +129,26 @@ TEST(SfinaeTest, iota) {
 
 TEST(SfinaeTest, any_view) {
     static_assert(std::constructible_from<any_view<int>, any_view<int, input | copyable>>);
-    // does not copy construct copyable any_view because std::views::all decays it
+    // any_view<int> is not copyable
+    static_assert(not std::constructible_from<any_view<int>, any_view<int>&>);
+    static_assert(std::constructible_from<any_view<int>, any_view<int, input | copyable>&>);
+    // const any_view<int, input | copyable> does not model range
     static_assert(not std::constructible_from<any_view<int>, const any_view<int, input | copyable>&>);
 }
 
 TEST(SfinaeTest, default_view) {
     static_assert(std::default_initializable<any_view<int, contiguous | sized | borrowed | copyable>>);
+}
+
+template <class T>
+struct my_range {
+    my_range(T);
+
+    int* begin();
+    int* end();
+};
+
+TEST(SfinaeTest, user_range) {
+    // R5 any_view constructor causes constraint to depend on itself
+    static_assert(std::ranges::viewable_range<my_range<any_view<int>>>);
 }


### PR DESCRIPTION
<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->

This implements a change applied in R6.