### PR TITLE
Add lifetimebound attribute

### DIFF
--- a/include/beman/any_view/CMakeLists.txt
+++ b/include/beman/any_view/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
                 detail/default_iterator.hpp
                 detail/default_view.hpp
                 detail/iterator.hpp
+                detail/lifetimebound.hpp
                 detail/no_unique_address.hpp
                 detail/polymorphic.hpp
                 detail/polymorphic_iterator.hpp

--- a/include/beman/any_view/any_view.hpp
+++ b/include/beman/any_view/any_view.hpp
@@ -5,6 +5,7 @@
 
 #include <beman/any_view/concepts.hpp>
 #include <beman/any_view/detail/iterator.hpp>
+#include <beman/any_view/detail/lifetimebound.hpp>
 #include <beman/any_view/detail/polymorphic_view.hpp>
 
 namespace beman::any_view {
@@ -131,6 +132,20 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
                           "range must be convertible to copyable view if any_view is copyable");
         }
     }
+
+#ifdef BEMAN_ANY_VIEW_LIFETIMEBOUND
+    template <class RangeT>
+        requires(not std::ranges::enable_view<std::remove_cv_t<RangeT>>) and
+                ext_any_compatible_range<RangeT&, RefT, RValueRefT, DiffT, OptsV>
+    constexpr any_view(BEMAN_ANY_VIEW_LIFETIMEBOUND RangeT& range)
+        : poly(adaptor_for<std::views::all_t<RangeT&>>{.view = std::views::all(range)}) {
+        static_assert(std::ranges::viewable_range<RangeT&>, "range must be viewable");
+        if constexpr (copyable) {
+            static_assert(std::copyable<std::views::all_t<RangeT&>>,
+                          "range must be convertible to copyable view if any_view is copyable");
+        }
+    }
+#endif // BEMAN_ANY_VIEW_LIFETIMEBOUND
 
     constexpr any_view() noexcept = default;
 

--- a/include/beman/any_view/detail/lifetimebound.hpp
+++ b/include/beman/any_view/detail/lifetimebound.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef BEMAN_ANY_VIEW_DETAIL_LIFETIMEBOUND_HPP
+#define BEMAN_ANY_VIEW_DETAIL_LIFETIMEBOUND_HPP
+
+#ifndef BEMAN_ANY_VIEW_LIFETIMEBOUND
+    #ifdef __has_cpp_attribute
+        #if __has_cpp_attribute(clang::lifetimebound)
+            #define BEMAN_ANY_VIEW_LIFETIMEBOUND [[clang::lifetimebound]]
+        #elif __has_cpp_attribute(msvc::lifetimebound)
+            #define BEMAN_ANY_VIEW_LIFETIMEBOUND [[msvc::lifetimebound]]
+        #endif
+    #endif // __has_cpp_attribute
+#endif     // BEMAN_ANY_VIEW_LIFETIMEBOUND
+
+#endif // BEMAN_ANY_VIEW_DETAIL_LIFETIMEBOUND_HPP

--- a/include/beman/any_view/detail/no_unique_address.hpp
+++ b/include/beman/any_view/detail/no_unique_address.hpp
@@ -4,11 +4,15 @@
 #define BEMAN_ANY_VIEW_DETAIL_NO_UNIQUE_ADDRESS_HPP
 
 #ifndef BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS
-    #if _MSC_VER
+    #ifndef __has_cpp_attribute
+        #define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS
+    #elif __has_cpp_attribute(msvc::no_unique_address)
         #define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
-    #else
+    #elif __has_cpp_attribute(no_unique_address)
         #define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS [[no_unique_address]]
-    #endif // _MSC_VER
+    #else
+        #define BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS
+    #endif // __has_cpp_attribute
 #endif     // BEMAN_ANY_VIEW_NO_UNIQUE_ADDRESS
 
 #endif // BEMAN_ANY_VIEW_DETAIL_NO_UNIQUE_ADDRESS_HPP


### PR DESCRIPTION
<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->

Here's the motivating case:
```cpp
any_view<int> foo() {
    vector<int> vec;
    // return {vec};  // not ok, reference dangles
    return vec;  // ok, NRVO moves
}
```

Getting this return statement correct is subtle and error-prone, and the lifetimebound attribute helps catch dangling references as compilation errors.