### PR TITLE
Update copy assignment with copy swap idiom

### DIFF
--- a/include/beman/any_view/any_view.hpp
+++ b/include/beman/any_view/any_view.hpp
@@ -155,9 +155,12 @@ class any_view : public std::ranges::view_interface<any_view<ElementT, OptsV, Re
 
     constexpr any_view(any_view&& other) noexcept : poly(std::move(other).polymorphic()) {}
 
-    constexpr any_view& operator=(const any_view&)
+    constexpr any_view& operator=(const any_view& other)
         requires copyable
-    = default;
+    {
+        any_view(other).swap(*this);
+        return *this;
+    }
 
     constexpr any_view& operator=(any_view&& other) noexcept {
         any_view(std::move(other)).swap(*this);


### PR DESCRIPTION
<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->

This updates the copy assignment operator to have strong exception safety guarantee by using the copy swap idiom as specified in its effects under the proposal's wording.