### PR TITLE
Enable beman-tidy (--require-all mode) into beman.any_view

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,5 +45,6 @@ repos:
     rev: v0.5.1
     hooks:
     - id: beman-tidy
+      args: [".", "--verbose", "--require-all"]
 
 exclude: 'cookiecutter/|infra/|port/'


### PR DESCRIPTION
Issue: bemanproject/beman-tidy#250

Enable `beman-tidy --require-all` on CI for `beman.any_view`, following the same change as bemanproject/indices_view#14.

CODEOWNERS approval: @patrickroberts gave 👍 on the `--require-all` proposal in the issue.

## Test plan
- [x] `beman-tidy . --verbose --require-all` passes locally (100% requirement coverage)
- [x] CI pre-commit check passes